### PR TITLE
Fix Teamspeak Template

### DIFF
--- a/teamspeak3/teamspeak3.json
+++ b/teamspeak3/teamspeak3.json
@@ -10,7 +10,7 @@
         },
         {
           "commands": [
-            "tar -xvf teamspeak3-server_linux_amd64-{version}.tar.bz2",
+            "tar -xvf teamspeak3-server_linux_amd64-{version}.tar.bz2"
           ],
           "type": "command"
         }

--- a/teamspeak3/teamspeak3.json
+++ b/teamspeak3/teamspeak3.json
@@ -10,7 +10,7 @@
         },
         {
           "commands": [
-            "tar -xvf teamspeak3-server_linux_amd64-{version}.tar.bz2"
+            "tar -xvf teamspeak3-server_linux_amd64-${version}.tar.bz2"
           ],
           "type": "command"
         }


### PR DESCRIPTION
- Redundant/trailing commas are not supported in JSON: removed on Line 13
- Inline variable was not formatted correctly: added needed `$` on Line 13