### PR TITLE
Add ECO – Global Survival

### DIFF
--- a/eco/README.md
+++ b/eco/README.md
@@ -1,0 +1,16 @@
+# Template for [ECO – Global Survival](http://www.strangeloopgames.com/eco/)
+This template makes it possible to run [ECO – Global Survival](http://www.strangeloopgames.com/eco/) with [PufferPanel](https://www.pufferpanel.com/) on Linux.
+
+## Prerequisites
+* To use this template, you need to install `mono` on your server.
+To install `mono`, follow the instructions on [mono-project.com](https://www.mono-project.com/download/stable/) for your distribution.
+* You need the `unzip` command on your server. You can install `unzip` on Debian and Ubuntu with the following commands as root:
+  ```bash
+  apt-get update
+  apt-get install unzip
+  ```
+
+## Known issues
+* The ECO server will not start when used with mono version 5.16: https://github.com/StrangeLoopGames/EcoIssues/issues/9676
+
+  You can use version 5.14 instead.

--- a/eco/eco.json
+++ b/eco/eco.json
@@ -1,0 +1,77 @@
+{
+    "pufferd": {
+        "type": "mono",
+        "display": "ECO – Global Survival (via mono)",
+        "install": {
+            "commands": [
+                {
+                    "type": "download",
+                    "files": [
+                        "https://s3-us-west-2.amazonaws.com/eco-releases/EcoServer_v${serverVersion}.zip"
+                    ]
+                },
+                {
+                    "type": "command",
+                    "commands": [
+                        "unzip EcoServer_v*.zip",
+                        "rm EcoServer_v${serverVersion}.zip"
+                    ]
+                },
+                {
+                    "type": "writefile",
+                    "target": "Configs/Network.eco",
+                    "text": "{\n  \"PublicServer\": false,\n  \"Password\": \"${password}\",\n  \"Description\": \"\",\n  \"IPAddress\": \"${ip}\",\n  \"GameServerPort\": ${port},\n  \"WebServerPort\": ${webServerPort},\n  \"Rate\": 10,\n  \"MaxConnections\": -1\n}"
+                }
+            ]
+        },
+        "run": {
+            "stopCode": 9,
+            "pre": [],
+            "post": [],
+            "arguments": [
+                "EcoServer.exe",
+                "-nogui"
+            ],
+            "program": "mono"
+        },
+        "data": {
+            "ip": {
+                "value": "0.0.0.0",
+                "required": true,
+                "desc": "What IP to bind the Eco game server to.",
+                "display": "IP",
+                "internal": false
+            },
+            "port": {
+                "value": "3000",
+                "required": true,
+                "desc": "What port to bind the server to",
+                "display": "Game-Server Port",
+                "internal": false,
+                "type": "integer"
+            },
+            "webServerPort": {
+                "value": "3001",
+                "required": true,
+                "desc": "What port to bind the Eco web server to.",
+                "display": "Web-Server Port",
+                "internal": false,
+                "type": "integer"
+            },
+            "password": {
+                "value": "",
+                "required": false,
+                "desc": "Password for the Eco Game Server, which will be required for login.",
+                "display": "Password",
+                "internal": false
+            },
+            "serverVersion": {
+                "value": "0.7.7.2-beta",
+                "required": true,
+                "desc": "Version of Eco server to install.",
+                "display": "Server Version",
+                "internal": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've made a template for ECO. With this template it is possible to use PufferPanel with ECO game servers on linux systems running via mono.

See instructions in `README.md`.