### PR TITLE
Remove -universal

### DIFF
--- a/minecraft-forge/minecraft-forge-docker.json
+++ b/minecraft-forge/minecraft-forge-docker.json
@@ -30,7 +30,7 @@
           "target": "eula.txt"
         },
         {
-          "source": "forge-*-universal.jar",
+          "source": "forge-*.jar",
           "target": "server.jar",
           "type": "move"
         }

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -30,7 +30,7 @@
           "target": "eula.txt"
         },
         {
-          "source": "forge-*-universal.jar",
+          "source": "forge-*.jar",
           "target": "server.jar",
           "type": "move"
         }


### PR DESCRIPTION
Later versions of forge do not prepend with `-universal` (1.14.4-28.0.23 for example) this means the server will not start as it cannot find `server.jar`.

By removing the need for `-universal` any forge version will run. This does not cause issues with the installation process as the installer has already been renamed.