### PR TITLE
Amend Waterfall template to use Parchment API

### DIFF
--- a/minecraft-waterfall/minecraft-waterfall-docker.json
+++ b/minecraft-waterfall/minecraft-waterfall-docker.json
@@ -5,8 +5,13 @@
     "install": {
       "commands": [
         {
-          "files": "https://destroystokyo.com/ci/job/Waterfall/lastSuccessfulBuild/artifact/Waterfall-Proxy/bootstrap/target/Waterfall.jar",
+          "files": "https://papermc.io/api/v1/waterfall/${version}/latest/download",
           "type": "download"
+        },
+        {
+          "source": "waterfall-*.jar",
+          "target": "Waterfall.jar",
+          "type": "move"
         },
         {
           "type": "writefile",
@@ -32,6 +37,13 @@
       "image": "pufferpanel/minecraft"
     },
     "data": {
+      "version": {
+        "value": "1.14",
+        "required": true,
+        "desc": "Version of Minecraft to install. Must be specified as a <strong>minor release number</strong>, e.g. 1.14",
+        "display": "Version",
+        "internal": false
+      },
       "memory": {
         "value": "512",
         "required": true,

--- a/minecraft-waterfall/minecraft-waterfall.json
+++ b/minecraft-waterfall/minecraft-waterfall.json
@@ -5,8 +5,13 @@
     "install": {
       "commands": [
         {
-          "files": "https://destroystokyo.com/ci/job/Waterfall/lastSuccessfulBuild/artifact/Waterfall-Proxy/bootstrap/target/Waterfall.jar",
+          "files": "https://papermc.io/api/v1/waterfall/${version}/latest/download",
           "type": "download"
+        },
+        {
+          "source": "waterfall-*.jar",
+          "target": "Waterfall.jar",
+          "type": "move"
         },
         {
           "type": "writefile",
@@ -31,6 +36,13 @@
       "type": "standard"
     },
     "data": {
+      "version": {
+        "value": "1.14",
+        "required": true,
+        "desc": "Version of Minecraft to install. Must be specified as a <strong>minor release number</strong>, e.g. 1.14",
+        "display": "Version",
+        "internal": false
+      },
       "memory": {
         "value": "512",
         "required": true,


### PR DESCRIPTION
Updated to use Parchment. We now need to specify a minor version when downloading Waterfall, e.g. 1.14