### PR TITLE
Unturned Template

### DIFF
--- a/unturned/unturned.json
+++ b/unturned/unturned.json
@@ -1,0 +1,176 @@
+{
+    "data": {
+        "map": {
+            "desc": "Server map.",
+            "display": "Map",
+            "value": "PEI",
+            "type": "option",
+            "options": [
+                {
+                    "value": "PEI",
+                    "display": "PEI"
+                },
+                {
+                    "value": "Germany",
+                    "display": "Germany"
+                },
+                {
+                    "value": "Russia",
+                    "display": "Russia"
+                },
+                {
+                    "value": "Washington",
+                    "display": "Washington"
+                },
+                {
+                    "value": "Yukon",
+                    "display": "Yukon"
+                }
+            ]
+        },
+        "maxplayers": {
+            "desc": "Slots",
+            "display": "Server slots",
+            "value": "24",
+            "type": "integer"
+        },
+        "mode": {
+            "desc": "Game difficulty",
+            "display": "Mode",
+            "required": true,
+            "value": "normal",
+            "type": "option",
+            "options": [
+                {
+                    "value": "easy",
+                    "display": "Easy"
+                },
+                {
+                    "value": "normal",
+                    "display": "Normal"
+                },
+                {
+                    "value": "hard",
+                    "display": "Hard"
+                }
+            ]
+        },
+        "name": {
+            "desc": "Server name",
+            "display": "Name",
+            "required": true,
+            "value": "Unturned Server",
+            "type": "string"
+        },
+        "password": {
+            "desc": "Password users enter to join server",
+            "display": "Server password",
+            "value": "",
+            "type": "string"
+        },
+        "perspective": {
+            "desc": "Perspective of the server",
+            "display": "Perspective",
+            "value": "",
+            "type": "option",
+            "options": [
+                {
+                    "value": "First",
+                    "display": "First"
+                },
+                {
+                    "value": "Third",
+                    "display": "Third"
+                },
+                {
+                    "value": "Both",
+                    "display": "Both"
+                },
+                {
+                    "value": "Vehicle",
+                    "display": "Vehicle"
+                }
+            ]
+        },
+        "port": {
+            "desc": "Server port.",
+            "display": "Port",
+            "required": true,
+            "value": "27015",
+            "type": "integer"
+        },
+        "server": {
+            "desc": "Server name under Servers folder",
+            "display": "Server",
+            "value": "Default",
+            "type": "string"
+        },
+        "steam_id": {
+            "desc": "Server owner STEAMID_64",
+            "display": "STEAMID_64",
+            "required": true,
+            "value": "",
+            "type": "string"
+        },
+        "welcome": {
+            "desc": "Welcome",
+            "display": "Server welcome message",
+            "required": true,
+            "value": "Welcome to the server!",
+            "type": "string"
+        }
+    },
+    "display": "Unturned",
+    "environment": {
+        "type": "tty"
+    },
+    "install": [
+        {
+            "commands": [
+                "mkdir steamcmd"
+            ],
+            "type": "command"
+        },
+        {
+            "files": [
+                "http://media.steampowered.com/client/steamcmd_linux.tar.gz"
+            ],
+            "type": "download"
+        },
+        {
+            "commands": [
+                "mv steamcmd_linux.tar.gz steamcmd",
+                "tar -xvzf steamcmd/steamcmd_linux.tar.gz -C steamcmd",
+                "rm steamcmd/steamcmd_linux.tar.gz",
+                "./steamcmd/steamcmd.sh +login anonymous +force_install_dir ../ +app_update 1110390 validate +exit"
+            ],
+            "type": "command"
+        },
+        {
+            "commands": [
+                "mkdir Servers/${server}",
+                "mkdir Servers/${server}/Server/"
+            ],
+            "type": "command"
+        },
+        {
+            "target": "/Servers/${server}/Server/Commands.dat",
+            "text": "Name ${name}\nMap ${map}\nPort ${port}\nMaxPlayers ${maxplayers}\nMode ${mode}\nOwner ${steam_id}\nWelcome ${welcome}\nPassword ${password}\nPerspective ${perspective}",
+            "type": "writefile"
+        }
+    ],
+    "type": "steamcmd",
+    "run": {
+        "command": "./ServerHelper.sh",
+        "stop": "shutdown",
+        "environmentVars": {},
+        "pre": [],
+        "post": []
+    },
+    "supportedEnvironments": [
+        {
+            "type": "tty"
+        }
+    ],
+    "name": "Unturned"
+}


### PR DESCRIPTION
Use https://developer.valvesoftware.com/wiki/SteamCMD#Downloading_SteamCMD to install steamcmd along with the required dependencies. You can delete this steamcmd afterwards as the template will download and install its own standalone steamcmd.