### PR TITLE
Update dontstarvetogether.json

### DIFF
--- a/dontstarvetogether/dontstarvetogether.json
+++ b/dontstarvetogether/dontstarvetogether.json
@@ -17,7 +17,7 @@
             "type": "integer"
         },
         "servertoken": {
-            "desc": "Dont Starve Together Server Token (may find here <a href=\"https://accounts.klei.com/account/game/servers?game=DontStarveTogether\">here</a>",
+            "desc": "Dont Starve Together Server Token (may find here <a href=\"https://accounts.klei.com/account/game/servers?game=DontStarveTogether\" target="_blank">here</a>)",
             "display": "Server Token",
             "required": true,
             "value": "",


### PR DESCRIPTION
You should default to opening the link in a new tab, so that users don't leave their configuration session and have to start over