### PR TITLE
Updated to use the new version of paper api

### DIFF
--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -4,7 +4,7 @@
   "install": [
     {
       "type": "download",
-      "files": "https://papermc.io/api/v1/paper/${version}/latest/download"
+      "files": "https://papermc.io/api/v2/projects/paper/versions/${version}/builds/${build}/downloads/paper-${version}-${build}.jar"
     },
     {
       "type": "move",
@@ -48,10 +48,17 @@
   ],
   "data": {
     "version": {
-      "value": "1.16.3",
+      "value": "1.16.5",
       "required": true,
-      "desc": "Version of Minecraft to install (<a href='https://papermc.io/downloads'>Paper maintained versions</a>). Must be specified as a release number, e.g. 1.16.3",
+      "desc": "Version of Minecraft to install (<a href='https://papermc.io/downloads'>Paper maintained versions</a>). Must be specified as a release number, e.g. 1.16.5",
       "display": "Version",
+      "internal": false
+    },
+    "build": {
+      "value": "484",
+      "required": true,
+      "desc": "Build of Paper to install (<a href='https://papermc.io/downloads'>Paper version build</a>). Must be specified as a build number, e.g. 484",
+      "display": "build",
       "internal": false
     },
     "memory": {


### PR DESCRIPTION
the old version of paper api is now gone, so we need to use the new v2