### PR TITLE
game version works now

### DIFF
--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -51,7 +51,7 @@
         },
         {
             "commands": [
-                "java -jar fabric-installer.jar server -downloadMinecraft -noprofile"
+                "java -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
             ],
             "type": "command"
         },


### PR DESCRIPTION
I realized the other day that the game version selector didn't work and it would just install the latest. This fixes it.