### PR TITLE
add the ability to "choose" different java versions

### DIFF
--- a/feedthebeast/feedthebeast.json
+++ b/feedthebeast/feedthebeast.json
@@ -30,7 +30,7 @@
     }
   ],
   "run": {
-    "command": "{java} -server -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar ForgeServer.jar nogui",
+    "command": "${java} -server -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar ForgeServer.jar nogui",
     "stop": "stop",
     "pre": [],
     "post": []

--- a/feedthebeast/feedthebeast.json
+++ b/feedthebeast/feedthebeast.json
@@ -30,7 +30,7 @@
     }
   ],
   "run": {
-    "command": "java -server -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar ForgeServer.jar nogui",
+    "command": "{java} -server -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar ForgeServer.jar nogui",
     "stop": "stop",
     "pre": [],
     "post": []
@@ -48,6 +48,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "eula": {
       "value": "false",
       "required": true,

--- a/minecraft-bungeecord/minecraft-bungeecord.json
+++ b/minecraft-bungeecord/minecraft-bungeecord.json
@@ -16,7 +16,7 @@
     "stop": "end",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Xms${memory}M -jar BungeeCord.jar"
+    "command": "{java} -Xmx${memory}M -Xms${memory}M -jar BungeeCord.jar"
   },
   "environment": {
     "type": "standard"
@@ -31,6 +31,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "memory": {
       "value": "512",
       "required": true,

--- a/minecraft-bungeecord/minecraft-bungeecord.json
+++ b/minecraft-bungeecord/minecraft-bungeecord.json
@@ -16,7 +16,7 @@
     "stop": "end",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Xms${memory}M -jar BungeeCord.jar"
+    "command": "${java} -Xmx${memory}M -Xms${memory}M -jar BungeeCord.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -1,6 +1,15 @@
 {
     "type": "minecraft-java",
     "data": {
+        "java": {
+            "value": "java",
+            "required": true,
+            "desc": "\"java\" for system standard, else direct path to java",
+            "display": "path to java executable",
+            "internal": false,
+            "type": "string",
+            "userEdit": true
+        },
         "eula": {
             "type": "boolean",
             "desc": "Do you (or the server owner) agree to the <a href='https://account.mojang.com/documents/minecraft_eula'>Minecraft EULA?</a>",
@@ -51,7 +60,7 @@
         },
         {
             "commands": [
-                "java -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
+                "{java} -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
             ],
             "type": "command"
         },
@@ -85,7 +94,7 @@
         }
     ],
     "run": {
-        "command": "java -Xmx${memory}M -jar fabric-server.jar nogui",
+        "command": "{java} -Xmx${memory}M -jar fabric-server.jar nogui",
         "stop": "stop",
         "environmentVars": {},
         "pre": [],

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -60,7 +60,7 @@
         },
         {
             "commands": [
-                "{java} -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
+                "${java} -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
             ],
             "type": "command"
         },

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -94,7 +94,7 @@
         }
     ],
     "run": {
-        "command": "{java} -Xmx${memory}M -jar fabric-server.jar nogui",
+        "command": "${java} -Xmx${memory}M -jar fabric-server.jar nogui",
         "stop": "stop",
         "environmentVars": {},
         "pre": [],

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -13,7 +13,7 @@
     },
     {
       "commands": [
-        "{java} -jar installer.jar --installServer"
+        "${java} -jar installer.jar --installServer"
       ],
       "type": "command"
     },
@@ -37,7 +37,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar"
+    "command": "${java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -13,7 +13,7 @@
     },
     {
       "commands": [
-        "java -jar installer.jar --installServer"
+        "{java} -jar installer.jar --installServer"
       ],
       "type": "command"
     },
@@ -37,7 +37,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar"
+    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar"
   },
   "environment": {
     "type": "standard"
@@ -52,6 +52,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "memory": {
       "value": "1024",
       "required": true,

--- a/minecraft-magma/minecraft-magma.json
+++ b/minecraft-magma/minecraft-magma.json
@@ -83,7 +83,7 @@
     ],
     "type": "minecraft-java",
     "run": {
-        "command": "{java} -Xmx${memory}M -jar server.jar",
+        "command": "${java} -Xmx${memory}M -jar server.jar",
         "environmentVars": {},
         "pre": [],
         "post": [],

--- a/minecraft-magma/minecraft-magma.json
+++ b/minecraft-magma/minecraft-magma.json
@@ -1,5 +1,14 @@
 {
     "data": {
+        "java": {
+            "value": "java",
+            "required": true,
+            "desc": "\"java\" for system standard, else direct path to java",
+            "display": "path to java executable",
+            "internal": false,
+            "type": "string",
+            "userEdit": true
+        },
         "eula": {
             "desc": "Do you (or the server owner) agree to the <a href='https://account.mojang.com/documents/minecraft_eula'>Minecraft EULA?</a>",
             "display": "EULA Agreement (true/false)",
@@ -74,7 +83,7 @@
     ],
     "type": "minecraft-java",
     "run": {
-        "command": "java -Xmx${memory}M -jar server.jar",
+        "command": "{java} -Xmx${memory}M -jar server.jar",
         "environmentVars": {},
         "pre": [],
         "post": [],

--- a/minecraft-nukkit/minecraft-nukkit.json
+++ b/minecraft-nukkit/minecraft-nukkit.json
@@ -26,7 +26,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar nukkit.jar"
+    "command": "${java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar nukkit.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-nukkit/minecraft-nukkit.json
+++ b/minecraft-nukkit/minecraft-nukkit.json
@@ -26,7 +26,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar nukkit.jar"
+    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar nukkit.jar"
   },
   "environment": {
     "type": "standard"
@@ -41,6 +41,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "memory": {
       "value": "1024",
       "required": true,

--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -26,7 +26,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar paper.jar"
+    "command": "${java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar paper.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -26,7 +26,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar paper.jar"
+    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar paper.jar"
   },
   "environment": {
     "type": "standard"
@@ -41,6 +41,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "version": {
       "value": "1.16.5",
       "required": true,

--- a/minecraft-purpur/minecraft-purpur.json
+++ b/minecraft-purpur/minecraft-purpur.json
@@ -26,7 +26,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar purpurclip.jar"
+    "command": "${java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar purpurclip.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-purpur/minecraft-purpur.json
+++ b/minecraft-purpur/minecraft-purpur.json
@@ -26,7 +26,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar purpurclip.jar"
+    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -jar purpurclip.jar"
   },
   "environment": {
     "type": "standard"
@@ -41,6 +41,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "version": {
       "value": "1.16.3",
       "required": true,

--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -32,7 +32,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Djline.terminal=jline.UnsupportedTerminal -jar server.jar"
+    "command": "{java} -Xmx${memory}M -Djline.terminal=jline.UnsupportedTerminal -jar server.jar"
   },
   "environment": {
     "type": "standard"
@@ -47,6 +47,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "version": {
       "value": "latest",
       "required": true,

--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -32,7 +32,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Djline.terminal=jline.UnsupportedTerminal -jar server.jar"
+    "command": "${java} -Xmx${memory}M -Djline.terminal=jline.UnsupportedTerminal -jar server.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-sponge/minecraft-sponge.json
+++ b/minecraft-sponge/minecraft-sponge.json
@@ -46,7 +46,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true ${extraArgs} -jar server.jar"
+    "command": "${java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true ${extraArgs} -jar server.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-sponge/minecraft-sponge.json
+++ b/minecraft-sponge/minecraft-sponge.json
@@ -23,7 +23,7 @@
     {
       "type": "command",
       "commands": [
-        "java -jar installer.jar --installServer"
+        "{java} -jar installer.jar --installServer"
       ]
     },
     {
@@ -46,7 +46,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true ${extraArgs} -jar server.jar"
+    "command": "{java} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true ${extraArgs} -jar server.jar"
   },
   "environment": {
     "type": "standard"
@@ -61,6 +61,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "memory": {
       "value": "1024",
       "required": true,

--- a/minecraft-sponge/minecraft-sponge.json
+++ b/minecraft-sponge/minecraft-sponge.json
@@ -23,7 +23,7 @@
     {
       "type": "command",
       "commands": [
-        "{java} -jar installer.jar --installServer"
+        "${java} -jar installer.jar --installServer"
       ]
     },
     {

--- a/minecraft-vanilla/minecraft-vanilla.json
+++ b/minecraft-vanilla/minecraft-vanilla.json
@@ -22,7 +22,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -jar server.jar"
+    "command": "${java} -Xmx${memory}M -jar server.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-vanilla/minecraft-vanilla.json
+++ b/minecraft-vanilla/minecraft-vanilla.json
@@ -22,7 +22,7 @@
     "stop": "stop",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -jar server.jar"
+    "command": "{java} -Xmx${memory}M -jar server.jar"
   },
   "environment": {
     "type": "standard"
@@ -37,6 +37,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "version": {
       "value": "latest",
       "required": true,

--- a/minecraft-velocity/minecraft-velocity.json
+++ b/minecraft-velocity/minecraft-velocity.json
@@ -69,7 +69,7 @@
         }
     ],
     "run": {
-        "command": "{java} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar velocity.jar",
+        "command": "${java} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar velocity.jar",
         "stop": "shutdown",
         "environmentVars": {},
         "pre": [],

--- a/minecraft-velocity/minecraft-velocity.json
+++ b/minecraft-velocity/minecraft-velocity.json
@@ -1,6 +1,15 @@
 {
     "type": "minecraft-java",
     "data": {
+        "java": {
+            "value": "java",
+            "required": true,
+            "desc": "\"java\" for system standard, else direct path to java",
+            "display": "path to java executable",
+            "internal": false,
+            "type": "string",
+            "userEdit": true
+        },
         "ip": {
             "type": "string",
             "desc": "What IP to bind the server to",
@@ -60,7 +69,7 @@
         }
     ],
     "run": {
-        "command": "java -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar velocity.jar",
+        "command": "{java} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar velocity.jar",
         "stop": "shutdown",
         "environmentVars": {},
         "pre": [],

--- a/minecraft-waterfall/minecraft-waterfall.json
+++ b/minecraft-waterfall/minecraft-waterfall.json
@@ -21,7 +21,7 @@
     "stop": "end",
     "pre": [],
     "post": [],
-    "command": "{java} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar Waterfall.jar"
+    "command": "${java} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar Waterfall.jar"
   },
   "environment": {
     "type": "standard"

--- a/minecraft-waterfall/minecraft-waterfall.json
+++ b/minecraft-waterfall/minecraft-waterfall.json
@@ -21,7 +21,7 @@
     "stop": "end",
     "pre": [],
     "post": [],
-    "command": "java -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar Waterfall.jar"
+    "command": "{java} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -jar Waterfall.jar"
   },
   "environment": {
     "type": "standard"
@@ -36,6 +36,15 @@
     }
   ],
   "data": {
+    "java": {
+      "value": "java",
+      "required": true,
+      "desc": "\"java\" for system standard, else direct path to java",
+      "display": "path to java executable",
+      "internal": false,
+      "type": "string",
+      "userEdit": true
+    },
     "version": {
       "value": "1.16",
       "required": true,


### PR DESCRIPTION
This adds a java variable to the templates using java (just Minecraft ones iirc).

It allows the user to easily handle servers with different java versions as Minecraft 1.8 for Example needs java 8, but higher Minecraft versions also support higher java versions and some plugins are compiled in a more recent java version which leads to the problem where you will need different java versions for different Minecraft servers.