### PR TITLE
Fixed imposter.json

### DIFF
--- a/imposter/imposter.json
+++ b/imposter/imposter.json
@@ -45,13 +45,13 @@
     "install": [
         {
             "files": [
-                "https://github.com/AeonLucid/Impostor/releases/download/v${version}/Impostor-Server-linux-x64.zip"
+                "https://github.com/AeonLucid/Impostor/releases/download/v${version}/Impostor-Server_${version}_linux-x64.zip"
             ],
             "type": "download"
         },
         {
             "commands": [
-                "unzip Impostor-Server-linux-x64.zip"
+                "unzip Impostor-Server_${version}_linux-x64.zip"
             ],
             "type": "command"
         },


### PR DESCRIPTION
Updated the imposter server to now work with version 1.1.0 and above. This configuration won't work with the version 1.0.0.