### PR TITLE
Update minecraft-paper.json

### DIFF
--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -58,7 +58,7 @@
       "internal": false
     },
     "build": {
-      "value": "484",
+      "value": "634",
       "required": true,
       "desc": "Build of Paper to install (<a href='https://papermc.io/downloads'>Paper version build</a>). Must be specified as a build number, e.g. 484",
       "display": "build",


### PR DESCRIPTION
If you run the current image, ypu get a message talking about an outdated build.

498 is far behind the latest stable 634 build.

https://papermc.io/downloads 

