### PR TITLE
Use java specified by user to install spigot

### DIFF
--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -9,7 +9,7 @@
     {
       "type": "command",
       "commands": [
-        "java -jar BuildTools.jar --rev ${version}"
+        "${java} -jar BuildTools.jar --rev ${version}"
       ]
     },
     {


### PR DESCRIPTION
No, we need lot of java different for install spigot (Java 8,16,17), but we can't add 2 java in same path, so to install spigot, we need to modify java path system.
This change make the possibility for users to choice the java used to run BuildTool.