### PR TITLE
Update Project Zomboid template to work with the latest build (b41)

### DIFF
--- a/zomboid/zomboid.json
+++ b/zomboid/zomboid.json
@@ -1,78 +1,86 @@
 {
-    "type": "zomboid",
-    "data": {
-        "adminpassword": {
-            "type": "string",
-            "desc": "Password for admin account",
-            "display": "Admin Password",
-            "required": true,
-            "value": "password",
-            "userEdit": true
-        },
-        "port": {
-            "type": "integer",
-            "desc": "Base port (UDP) for server. Additional ports (TCP) beyond this will need to be opened. 1 per user.",
-            "display": "port",
-            "required": true,
-            "value": "16261",
-            "userEdit": true
-        },
-        "steamvac": {
-            "type": "boolean",
-            "desc": "Enable or disable Steam VAC",
-            "display": "steamvac",
-            "required": true,
-            "value": "true",
-            "userEdit": true
-        }
+  "name": "zomboid",
+  "display": "Project Zomboid",
+  "type": "zomboid",
+  "install": [
+    {
+      "files": [
+        "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
+      ],
+      "type": "download"
     },
-    "display": "Project Zomboid",
-    "environment": {
-        "type": "tty"
+    {
+      "commands": [
+        "mkdir steamcmd",
+        "tar --no-same-owner -xzvf steamcmd_linux.tar.gz -C steamcmd",
+        "steamcmd/steamcmd.sh +login anonymous +force_install_dir .. +app_update 380870 +quit",
+        "mkdir -p .steam/sdk32",
+        "cp steamcmd/linux32/steamclient.so .steam/sdk32/steamclient.so"
+      ],
+      "type": "command"
     },
-    "install": [
-        {
-            "files": [
-                "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
-            ],
-            "type": "download"
-        },
-        {
-            "commands": [
-                "mkdir steamcmd",
-                "tar --no-same-owner -xzvf steamcmd_linux.tar.gz -C steamcmd",
-                "steamcmd/steamcmd.sh +login anonymous +force_install_dir .. +app_update 380870 +quit",
-                "mkdir -p .steam/sdk32",
-                "cp steamcmd/linux32/steamclient.so .steam/sdk32/steamclient.so"
-            ],
-            "type": "command"
-        },
-        {
-            "target": "ProjectZomboid64.json",
-            "text": "{\n        \"mainClass\": \"zombie/network/GameServer\",\n        \"classpath\": [\n                \"java/\",\n                \"java/jinput.jar\",\n                \"java/lwjgl.jar\",\n                \"java/lwjgl_util.jar\",\n    \"java/trove-3.0.3.jar\",\n                \"java/sqlite-jdbc-3.8.10.1.jar\",\n                \"java/uncommons-maths-1.2.3.jar\",\n    \"java/javacord-2.0.17-shaded.jar\",\n    \"java/guava-23.0.jar\"\n        ],\n        \"vmArgs\": [\n                \"-Xms2048m\",\n                \"-Xmx2048m\",\n                \"-Duser.home=.\",\n                \"-Dzomboid.steam=1\",\n                \"-Dzomboid.znetlog=1\",\n                \"-Djava.library.path=linux64/:natives/\",\n                \"-XX:-UseSplitVerifier\",\n                \"-Djava.security.egd=file:/dev/urandom\",\n                \"-XX:+UseConcMarkSweepGC\",\n                \"-XX:-OmitStackTraceInFastThrow\"\n        ]\n}",
-            "type": "writefile"
-        },
-        {
-            "target": "ProjectZomboid32.json",
-            "text": "{\n        \"mainClass\": \"zombie/network/GameServer\",\n        \"classpath\": [\n                \"java/\",\n                \"java/jinput.jar\",\n                \"java/lwjgl.jar\",\n                \"java/lwjgl_util.jar\",\n    \"java/trove-3.0.3.jar\",\n                \"java/sqlite-jdbc-3.8.10.1.jar\",\n                \"java/uncommons-maths-1.2.3.jar\",\n    \"java/javacord-2.0.17-shaded.jar\",\n    \"java/guava-23.0.jar\"\n        ],\n        \"vmArgs\": [\n                \"-Xms768m\",\n                \"-Xmx768m\",\n                \"-Duser.home=.\",\n                \"-Dzomboid.steam=1\",\n                \"-Dzomboid.znetlog=1\",\n                \"-Djava.library.path=linux32/:natives/\",\n                \"-XX:-UseSplitVerifier\",\n                \"-Djava.security.egd=file:/dev/urandom\",\n                \"-XX:+UseConcMarkSweepGC\",\n                \"-XX:-OmitStackTraceInFastThrow\"\n        ]\n}\n",
-            "type": "writefile"
-        }
-    ],
-    "run": {
-        "command": "bash start-server.sh -adminpassword ${adminpassword} -steamvac ${steamvac} -port ${port}",
-        "stop": "quit",
-        "environmentVars": {},
-        "pre": [],
-        "post": []
+    {
+      "target": "ProjectZomboid64.json",
+      "text": "{\n\t\"mainClass\": \"zombie/network/GameServer\",\n\t\"classpath\": [\n\t\t\"java/.\",\n\t\t\"java/istack-commons-runtime.jar\",\n\t\t\"java/jassimp.jar\",\n\t\t\"java/javacord-2.0.17-shaded.jar\",\n\t\t\"java/javax.activation-api.jar\",\n\t\t\"java/jaxb-api.jar\",\n\t\t\"java/jaxb-runtime.jar\",\n\t\t\"java/lwjgl.jar\",\n\t\t\"java/lwjgl-natives-linux.jar\",\n\t\t\"java/lwjgl-glfw.jar\",\n\t\t\"java/lwjgl-glfw-natives-linux.jar\",\n\t\t\"java/lwjgl-jemalloc.jar\",\n\t\t\"java/lwjgl-jemalloc-natives-linux.jar\",\n\t\t\"java/lwjgl-opengl.jar\",\n\t\t\"java/lwjgl-opengl-natives-linux.jar\",\n\t\t\"java/lwjgl_util.jar\",\n\t\t\"java/sqlite-jdbc-3.27.2.1.jar\",\n\t\t\"java/trove-3.0.3.jar\",\n\t\t\"java/uncommons-maths-1.2.3.jar\"\n\t],\n\t\"vmArgs\": [\n\t\t\"-Djava.awt.headless=true\",\n\t\t\"-Xmx8g\",\n\t\t\"-Dzomboid.steam=1\",\n\t\t\"-Dzomboid.znetlog=1\",\n\t\t\"-Djava.library.path=linux64/:natives/\",\n        \"-Duser.home=./\",\n\t\t\"-Djava.security.egd=file:/dev/urandom\",\n\t\t\"-XX:+UseZGC\",\n\t\t\"-XX:-OmitStackTraceInFastThrow\"\n\t]\n}",
+      "type": "writefile"
     },
-    "supportedEnvironments": [
-        {
-            "type": "tty"
-        },
-        {
-            "image": "pufferpanel/srcds",
-            "type": "docker"
-        }
-    ],
-    "name": "Zomboid"
+    {
+      "target": "ProjectZomboid32.json",
+      "text": "{\n\t\"mainClass\": \"zombie/network/GameServer\",\n\t\"classpath\": [\n\t\t\"java/.\",\n\t\t\"java/istack-commons-runtime.jar\",\n\t\t\"java/jassimp.jar\",\n\t\t\"java/javacord-2.0.17-shaded.jar\",\n\t\t\"java/javax.activation-api.jar\",\n\t\t\"java/jaxb-api.jar\",\n\t\t\"java/jaxb-runtime.jar\",\n\t\t\"java/lwjgl.jar\",\n\t\t\"java/lwjgl-natives-linux.jar\",\n\t\t\"java/lwjgl-glfw.jar\",\n\t\t\"java/lwjgl-glfw-natives-linux.jar\",\n\t\t\"java/lwjgl-jemalloc.jar\",\n\t\t\"java/lwjgl-jemalloc-natives-linux.jar\",\n\t\t\"java/lwjgl-opengl.jar\",\n\t\t\"java/lwjgl-opengl-natives-linux.jar\",\n\t\t\"java/lwjgl_util.jar\",\n\t\t\"java/sqlite-jdbc-3.27.2.1.jar\",\n\t\t\"java/trove-3.0.3.jar\",\n\t\t\"java/uncommons-maths-1.2.3.jar\"\n\t],\n\t\"vmArgs\": [\n\t\t\"-Djava.awt.headless=true\",\n\t\t\"-Xms768m\",\n\t\t\"-Xmx768m\",\n\t\t\"-Dzomboid.steam=1\",\n\t\t\"-Dzomboid.znetlog=1\",\n\t\t\"-Djava.library.path=linux32/:natives/\",\n        \"-Duser.home=./\",\n\t\t\"-Djava.security.egd=file:/dev/urandom\",\n\t\t\"-XX:+UseG1GC\",\n\t\t\"-XX:-OmitStackTraceInFastThrow\"\n\t]\n}",
+      "type": "writefile"
+    }
+  ],
+  "run": {
+    "stop": "quit",
+    "command": "bash start-server.sh -servername ${serverName} -adminpassword ${adminPassword} -steamvac ${steamVAC} -port ${port}",
+    "workingDirectory": "",
+    "pre": [],
+    "post": [],
+    "environmentVars": {}
+  },
+  "data": {
+    "adminPassword": {
+      "type": "string",
+      "desc": "Password for admin account",
+      "display": "Admin Password",
+      "required": true,
+      "value": "password",
+      "userEdit": true
+    },
+    "port": {
+      "type": "integer",
+      "desc": "Base port (UDP) for server. Additional ports (TCP) beyond this will need to be opened. 1 per user.",
+      "display": "port",
+      "required": true,
+      "value": "16261",
+      "userEdit": true
+    },
+    "serverName": {
+      "type": "string",
+      "desc": "Name of the PZ server",
+      "display": "serverName",
+      "value": "pufferserver",
+      "userEdit": true
+    },
+    "steamVAC": {
+      "type": "boolean",
+      "desc": "Enable or disable Steam VAC",
+      "display": "steamVAC",
+      "required": true,
+      "value": "true",
+      "userEdit": true
+    }
+  },
+  "environment": {
+    "type": "tty"
+  },
+  "supportedEnvironments": [
+    {
+      "type": "tty"
+    },
+    {
+      "type": "docker",
+      "image": "pufferpanel/srcds"
+    }
+  ]
 }


### PR DESCRIPTION
- Updated contents of `ProjectZomboid32.json` and `ProjectZomboid64.json` to work with the current build (41)
- Added `-Duser.home=./` to ProjectZomboid32.json and ProjectZomboid64.json to put Zomboid server config and save folders where Pufferpanel's File browser can access them. By default PZ puts them out of easy reach in /root/Zomboid
- Added `serverName` var to easily change the server name

Closes https://github.com/PufferPanel/templates/issues/116