### PR TITLE
Update the paper URL to use the new API subdomain

### DIFF
--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -3,7 +3,7 @@
   "display": "Paper - Minecraft",
   "install": [{
       "type": "download",
-      "files": "https://papermc.io/api/v2/projects/paper/versions/${version}/builds/${build}/downloads/paper-${version}-${build}.jar"
+      "files": "https://api.papermc.io/v2/projects/paper/versions/${version}/builds/${build}/downloads/paper-${version}-${build}.jar"
     },
     {
       "type": "move",


### PR DESCRIPTION
PaperMC have now set up a subdomain for the API at https://api.papermc.io/ which will eventually be replacing https://papermc.io/api/