### PR TITLE
Update the new installer format

### DIFF
--- a/feedthebeast/feedthebeast.json
+++ b/feedthebeast/feedthebeast.json
@@ -9,8 +9,8 @@
     {
       "type": "command",
       "commands": [
-        "chmod u+x serverinstall_${modpack_id}_${modpack_version}",
-        "./serverinstall_${modpack_id}_${modpack_version} --auto --noscript"
+        "chmod u+x linux",
+        "./linux ${modpack_id} ${modpack_version} --auto --noscript"
       ]
     },
     {


### PR DESCRIPTION
modpacks.ch.
you must put the modpi ID and version ID in the downloaded script. It now downloads as "linux"