### PR TITLE
Use the java version variable and don't download java twice for FTB templates.

### DIFF
--- a/minecraft-bungeecord/minecraft-bungeecord.json
+++ b/minecraft-bungeecord/minecraft-bungeecord.json
@@ -31,12 +31,19 @@
       "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "files": "http://ci.md-5.net/job/BungeeCord/lastSuccessfulBuild/artifact/bootstrap/target/BungeeCord.jar",
@@ -49,7 +56,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Xms${memory}M -Dlog4j2.formatMsgNoLookups=true -jar BungeeCord.jar",
+    "command": "java${javaversion} -Xmx${memory}M -Xms${memory}M -Dlog4j2.formatMsgNoLookups=true -jar BungeeCord.jar",
     "stop": "end"
   },
   "environment": {

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -43,19 +43,26 @@
       "display": "PORT",
       "required": true,
       "value": "25565"
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "type": "fabricdl"
     },
     {
       "commands": [
-        "java17 -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
+        "java${javaversion} -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
       ],
       "type": "command"
     },
@@ -89,7 +96,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar fabric-server.jar nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar fabric-server.jar nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-forge-117+/minecraft-forge-117+.json
+++ b/minecraft-forge-117+/minecraft-forge-117+.json
@@ -40,6 +40,12 @@
       "display": "Version",
       "internal": false
     },
+    "javaversion": {
+      "value": "17",
+      "required": true,
+      "desc": "Version of Java to use",
+      "display": "Java Version"
+    },
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
@@ -51,7 +57,7 @@
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "type": "forgedl",
@@ -60,7 +66,7 @@
     },
     {
       "commands": [
-        "java17 -jar installer.jar --installServer"
+        "java${javaversion} -jar installer.jar --installServer"
       ],
       "type": "command"
     },
@@ -76,7 +82,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true @libraries/net/minecraftforge/forge/${version}/unix_args.txt nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true @libraries/net/minecraftforge/forge/${version}/unix_args.txt nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -40,6 +40,12 @@
       "display": "Version",
       "internal": false
     },
+    "javaversion": {
+      "value": "8",
+      "required": true,
+      "desc": "Version of Java to use",
+      "display": "Java Version"
+    },
     "mc-version": {
       "type": "option",
       "desc": "On which Minecraft Version should forge be installed",
@@ -88,7 +94,7 @@
   "install": [
     {
       "type": "javadl",
-      "version": "8"
+      "version": "${javaversion}"
     },
     {
       "type": "forgedl",
@@ -97,7 +103,7 @@
     },
     {
       "commands": [
-        "java8 -jar installer.jar --installServer"
+        "java${javaversion} -jar installer.jar --installServer"
       ],
       "type": "command"
     },
@@ -118,7 +124,7 @@
     }
   ],
   "run": {
-    "command": "java8 -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-ftb-117+/minecraft-ftb-117+-docker.json
+++ b/minecraft-ftb-117+/minecraft-ftb-117+-docker.json
@@ -79,7 +79,7 @@
     {
       "commands": [
         "chmod u+x linux",
-        "./linux ${modpack_id} ${modpack_version} --auto --noscript"
+        "./linux ${modpack_id} ${modpack_version} --auto --noscript --nojava"
       ],
       "type": "command"
     },

--- a/minecraft-ftb-117+/minecraft-ftb-117+.json
+++ b/minecraft-ftb-117+/minecraft-ftb-117+.json
@@ -110,13 +110,13 @@
     },
     {
       "commands": [
-        "javajavaversion -jar forge-1.1*.*-installer.jar --installServer"
+        "java${javaversion} -jar forge-1.1*.*-installer.jar --installServer"
       ],
       "type": "command"
     }
   ],
   "run": {
-    "command": "javajavaversion -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Dlog4j2.formatMsgNoLookups=true -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true @libraries/net/minecraftforge/forge/${version}/unix_args.txt nogui",
+    "command": "java${javaversion} -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Dlog4j2.formatMsgNoLookups=true -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true @libraries/net/minecraftforge/forge/${version}/unix_args.txt nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-ftb-117+/minecraft-ftb-117+.json
+++ b/minecraft-ftb-117+/minecraft-ftb-117+.json
@@ -67,12 +67,18 @@
       "display": "Version",
       "required": true,
       "value": ""
+    },
+    "javaversion": {
+      "value": "17",
+      "required": true,
+      "desc": "Version of Java to use",
+      "display": "Java Version"
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "files": [
@@ -83,7 +89,7 @@
     {
       "commands": [
         "chmod u+x linux",
-        "./linux ${modpack_id} ${modpack_version} --auto --noscript"
+        "./linux ${modpack_id} ${modpack_version} --auto --noscript --nojava"
       ],
       "type": "command"
     },
@@ -104,13 +110,13 @@
     },
     {
       "commands": [
-        "java17 -jar forge-1.1*.*-installer.jar --installServer"
+        "javajavaversion -jar forge-1.1*.*-installer.jar --installServer"
       ],
       "type": "command"
     }
   ],
   "run": {
-    "command": "java17 -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Dlog4j2.formatMsgNoLookups=true -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true @libraries/net/minecraftforge/forge/${version}/unix_args.txt nogui",
+    "command": "javajavaversion -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -Dlog4j2.formatMsgNoLookups=true -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true @libraries/net/minecraftforge/forge/${version}/unix_args.txt nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-ftb-fabric/minecraft-ftb-fabric.json
+++ b/minecraft-ftb-fabric/minecraft-ftb-fabric.json
@@ -16,7 +16,7 @@
     {
       "commands": [
         "chmod u+x linux",
-        "./linux --auto --noscript"
+        "./linux ${modpack_id} ${modpack_version} --auto --noscript --nojava"
       ],
       "type": "command"
     },

--- a/minecraft-ftb/minecraft-ftb-docker.json
+++ b/minecraft-ftb/minecraft-ftb-docker.json
@@ -66,7 +66,7 @@
       "type": "command",
       "commands": [
         "chmod u+x linux",
-        "./linux ${modpack_id} ${modpack_version} --auto --noscript"
+        "./linux ${modpack_id} ${modpack_version} --auto --noscript --nojava"
       ]
     },
     {

--- a/minecraft-ftb/minecraft-ftb.json
+++ b/minecraft-ftb/minecraft-ftb.json
@@ -77,7 +77,7 @@
       "type": "command",
       "commands": [
         "chmod u+x linux",
-        "./linux ${modpack_id} ${modpack_version} --auto --noscript"
+        "./linux ${modpack_id} ${modpack_version} --auto --noscript --nojava"
       ]
     },
     {

--- a/minecraft-magma/minecraft-magma.json
+++ b/minecraft-magma/minecraft-magma.json
@@ -55,12 +55,19 @@
       "required": true,
       "value": "68e21495",
       "userEdit": true
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "files": [
@@ -85,7 +92,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -Dlog4j2.formatMsgNoLookups=true -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar server.jar nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -Dlog4j2.formatMsgNoLookups=true -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar server.jar nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-mohist/minecraft-mohist.json
+++ b/minecraft-mohist/minecraft-mohist.json
@@ -56,12 +56,19 @@
       "required": true,
       "value": "25565",
       "userEdit": true
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "files": [
@@ -86,7 +93,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -53,12 +53,19 @@
       "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "type": "download",
@@ -81,7 +88,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -Dlog4j2.formatMsgNoLookups=true -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar paper.jar nogui",
+    "command": "java{javaversion} -Xmx${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Djline.terminal=jline.UnsupportedTerminal -Dlog4j2.formatMsgNoLookups=true -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar paper.jar nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-quilt/minecraft-quilt.json
+++ b/minecraft-quilt/minecraft-quilt.json
@@ -44,12 +44,19 @@
       "display": "PORT",
       "required": true,
       "value": "25565"
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "files": [
@@ -64,7 +71,7 @@
     },
     {
       "commands": [
-        "java17 -jar quilt-installer.jar install server ${game-version} --download-server --install-dir=."
+        "java${javaversion} -jar quilt-installer.jar install server ${game-version} --download-server --install-dir=."
       ],
       "type": "command"
     },
@@ -99,7 +106,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar quilt-server.jar nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar quilt-server.jar nogui",
     "stop": "stop",
     "environmentVars": {},
     "pre": [],

--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -46,12 +46,19 @@
       "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "type": "download",
@@ -80,7 +87,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Djline.terminal=jline.UnsupportedTerminal -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Djline.terminal=jline.UnsupportedTerminal -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-vanilla/minecraft-vanilla.json
+++ b/minecraft-vanilla/minecraft-vanilla.json
@@ -46,12 +46,19 @@
       "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "type": "mojangdl",
@@ -70,7 +77,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
+    "command": "java${javaversion} -Xmx${memory}M -Dlog4j2.formatMsgNoLookups=true -jar server.jar nogui",
     "stop": "stop"
   },
   "environment": {

--- a/minecraft-velocity/minecraft-velocity.json
+++ b/minecraft-velocity/minecraft-velocity.json
@@ -45,12 +45,19 @@
       "display": "Port",
       "required": true,
       "value": "25565"
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "files": [
@@ -65,7 +72,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true -jar velocity.jar",
+    "command": "java${javaversion} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true -jar velocity.jar",
     "stop": "shutdown"
   },
   "environment": {

--- a/minecraft-waterfall/minecraft-waterfall.json
+++ b/minecraft-waterfall/minecraft-waterfall.json
@@ -43,12 +43,19 @@
       "display": "Version",
       "required": true,
       "value": "1.19"
+    },
+    "javaversion": {
+      "type": "integer",
+      "desc": "Version of Java to use",
+      "display": "Java Version",
+      "value": "17",
+      "required": true
     }
   },
   "install": [
     {
       "type": "javadl",
-      "version": "17"
+      "version": "${javaversion}"
     },
     {
       "files": [
@@ -68,7 +75,7 @@
     }
   ],
   "run": {
-    "command": "java17 -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true -jar Waterfall.jar",
+    "command": "java${javaversion} -Xmx${memory}M -Xms${memory}M -Dterminal.jline=false -Dterminal.ansi=true -Dlog4j2.formatMsgNoLookups=true -jar Waterfall.jar",
     "stop": "end"
   },
   "environment": {

--- a/pocketmine/pocketmine.json
+++ b/pocketmine/pocketmine.json
@@ -21,7 +21,7 @@
   "install": [
     {
       "type": "download",
-      "files": "https://raw.githubusercontent.com/pmmp/php-build-scripts/master/installer.sh"
+      "files": " https://get.pmmp.io"
     },
     {
       "type": "command",

--- a/pocketmine/pocketmine.json
+++ b/pocketmine/pocketmine.json
@@ -21,7 +21,7 @@
   "install": [
     {
       "type": "download",
-      "files": " https://get.pmmp.io"
+      "files": "https://get.pmmp.io"
     },
     {
       "type": "command",


### PR DESCRIPTION
Just a couple of changes I had thought of thanks to @Linx-ESP with #203 

- Update the Java templates to use the javaversion and stop version hardcoding where possible. 
- Add the `--nojava` flag to the FTB templates to prevent them from downloading Java a second time.