### PR TITLE
Changed default server-properties. Default enable whitelist and hide-online-players

### DIFF
--- a/minecraft-bungeecord/minecraft-bungeecord-docker.json
+++ b/minecraft-bungeecord/minecraft-bungeecord-docker.json
@@ -40,7 +40,7 @@
     },
     {
       "type": "writefile",
-      "text": "listeners:\n- query_port: ${port}\n  host: ${ip}:${port}\n  motd: '${motd}'\n",
+      "text": "listeners:\n- query_port: ${port}\n  host: ${ip}:${port}\n  motd: '${motd}'\n hide-online-players=true\n white-list=true \n",
       "target": "config.yml"
     }
   ],

--- a/minecraft-bungeecord/minecraft-bungeecord.json
+++ b/minecraft-bungeecord/minecraft-bungeecord.json
@@ -44,7 +44,7 @@
     },
     {
       "type": "writefile",
-      "text": "listeners:\n- query_port: ${port}\n  host: ${ip}:${port}\n  motd: '${motd}'\n",
+      "text": "listeners:\n- query_port: ${port}\n  host: ${ip}:${port}\n  motd: '${motd}'\n hide-online-players=true\n white-list=true \n",
       "target": "config.yml"
     }
   ],

--- a/minecraft-fabric/minecraft-fabric-docker.json
+++ b/minecraft-fabric/minecraft-fabric-docker.json
@@ -57,7 +57,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-fabric/minecraft-fabric-docker.json
+++ b/minecraft-fabric/minecraft-fabric-docker.json
@@ -57,7 +57,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -61,7 +61,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -61,7 +61,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-forge-117+/minecraft-forge-117+-docker.json
+++ b/minecraft-forge-117+/minecraft-forge-117+-docker.json
@@ -62,7 +62,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-forge-117+/minecraft-forge-117+-docker.json
+++ b/minecraft-forge-117+/minecraft-forge-117+-docker.json
@@ -62,7 +62,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-forge-117+/minecraft-forge-117+.json
+++ b/minecraft-forge-117+/minecraft-forge-117+.json
@@ -66,7 +66,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-forge-117+/minecraft-forge-117+.json
+++ b/minecraft-forge-117+/minecraft-forge-117+.json
@@ -66,7 +66,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-forge/minecraft-forge-docker.json
+++ b/minecraft-forge/minecraft-forge-docker.json
@@ -99,7 +99,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-forge/minecraft-forge-docker.json
+++ b/minecraft-forge/minecraft-forge-docker.json
@@ -99,7 +99,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -103,7 +103,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -103,7 +103,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-ftb-117+/minecraft-ftb-117+-docker.json
+++ b/minecraft-ftb-117+/minecraft-ftb-117+-docker.json
@@ -95,7 +95,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-ftb-117+/minecraft-ftb-117+-docker.json
+++ b/minecraft-ftb-117+/minecraft-ftb-117+-docker.json
@@ -95,7 +95,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-ftb-117+/minecraft-ftb-117+.json
+++ b/minecraft-ftb-117+/minecraft-ftb-117+.json
@@ -99,7 +99,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-ftb-117+/minecraft-ftb-117+.json
+++ b/minecraft-ftb-117+/minecraft-ftb-117+.json
@@ -99,7 +99,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-ftb-fabric/minecraft-ftb-fabric.json
+++ b/minecraft-ftb-fabric/minecraft-ftb-fabric.json
@@ -32,7 +32,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     }
   ],

--- a/minecraft-ftb-fabric/minecraft-ftb-fabric.json
+++ b/minecraft-ftb-fabric/minecraft-ftb-fabric.json
@@ -16,7 +16,7 @@
     {
       "commands": [
         "chmod u+x linux",
-        "./linux --auto --noscript"
+        "./linux ${modpack_id} ${modpack_version} --auto --noscript"
       ],
       "type": "command"
     },

--- a/minecraft-ftb-fabric/minecraft-ftb-fabric.json
+++ b/minecraft-ftb-fabric/minecraft-ftb-fabric.json
@@ -32,7 +32,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     }
   ],

--- a/minecraft-ftb/minecraft-ftb-docker.json
+++ b/minecraft-ftb/minecraft-ftb-docker.json
@@ -81,7 +81,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     }
   ],

--- a/minecraft-ftb/minecraft-ftb-docker.json
+++ b/minecraft-ftb/minecraft-ftb-docker.json
@@ -81,7 +81,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     }
   ],

--- a/minecraft-ftb/minecraft-ftb.json
+++ b/minecraft-ftb/minecraft-ftb.json
@@ -92,7 +92,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     }
   ],

--- a/minecraft-ftb/minecraft-ftb.json
+++ b/minecraft-ftb/minecraft-ftb.json
@@ -92,7 +92,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     }
   ],

--- a/minecraft-magma/minecraft-magma-docker.json
+++ b/minecraft-magma/minecraft-magma-docker.json
@@ -71,7 +71,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-magma/minecraft-magma-docker.json
+++ b/minecraft-magma/minecraft-magma-docker.json
@@ -71,7 +71,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-magma/minecraft-magma.json
+++ b/minecraft-magma/minecraft-magma.json
@@ -75,7 +75,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-magma/minecraft-magma.json
+++ b/minecraft-magma/minecraft-magma.json
@@ -75,7 +75,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-mohist/minecraft-mohist-docker.json
+++ b/minecraft-mohist/minecraft-mohist-docker.json
@@ -72,7 +72,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-mohist/minecraft-mohist-docker.json
+++ b/minecraft-mohist/minecraft-mohist-docker.json
@@ -72,7 +72,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-mohist/minecraft-mohist.json
+++ b/minecraft-mohist/minecraft-mohist.json
@@ -76,7 +76,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-mohist/minecraft-mohist.json
+++ b/minecraft-mohist/minecraft-mohist.json
@@ -76,7 +76,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-paper/minecraft-paper-docker.json
+++ b/minecraft-paper/minecraft-paper-docker.json
@@ -67,7 +67,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-paper/minecraft-paper-docker.json
+++ b/minecraft-paper/minecraft-paper-docker.json
@@ -67,7 +67,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -71,7 +71,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -71,7 +71,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-quilt/minecraft-quilt.json
+++ b/minecraft-quilt/minecraft-quilt.json
@@ -70,7 +70,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "type": "writefile"
     },
     {

--- a/minecraft-quilt/minecraft-quilt.json
+++ b/minecraft-quilt/minecraft-quilt.json
@@ -70,7 +70,7 @@
     },
     {
       "target": "server.properties",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "type": "writefile"
     },
     {

--- a/minecraft-spigot/minecraft-spigot-docker.json
+++ b/minecraft-spigot/minecraft-spigot-docker.json
@@ -66,7 +66,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-spigot/minecraft-spigot-docker.json
+++ b/minecraft-spigot/minecraft-spigot-docker.json
@@ -66,7 +66,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -70,7 +70,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {

--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -70,7 +70,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-vanilla/minecraft-vanilla.json
+++ b/minecraft-vanilla/minecraft-vanilla.json
@@ -60,7 +60,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true\n",
       "target": "server.properties"
     },
     {

--- a/minecraft-vanilla/minecraft-vanilla.json
+++ b/minecraft-vanilla/minecraft-vanilla.json
@@ -60,7 +60,7 @@
     },
     {
       "type": "writefile",
-      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
+      "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\nhide-online-players=true\nwhite-list=true",
       "target": "server.properties"
     },
     {


### PR DESCRIPTION
It doesn't enable enforce-whitelist. I don't know how it makes a difference or how it works, so it stays as it is.

Added line break `/n` at the end, not all templates had it before, didn't seem to cause issues anyway.  
(There are still small differences in how are written between templates.)

For waterfall/paper/etc... might be better to leave them without this settings since their users are gonna be tweaking the server's config more often than.

> hide-online-players=true , hides list of players if not connected to the server (why is off by default??).  
> 
> whitelist=true , since the error when connecting for the first time is pretty clear about not being whitelisted, should be easy to solve for users while setting another layer of security.