### PR TITLE
Adjust the steamcmd docker image to an specific version

### DIFF
--- a/csgo/csgo-docker.json
+++ b/csgo/csgo-docker.json
@@ -102,7 +102,7 @@
   },
   "environment": {
     "type": "docker",
-    "image": "steamcmd/steamcmd"
+    "image": "steamcmd/steamcmd:ubuntu-20"
   },
   "requirements": {
     "arch": "amd64"


### PR DESCRIPTION
The CS GO dedicated server has gcc 7 as dependency and the latest steamcmd image is based on ubuntu 22.04 which doesn't have this version in the repos.