### PR TITLE
fix: factorio template should download the stable version

### DIFF
--- a/factorio/factorio.json
+++ b/factorio/factorio.json
@@ -2,6 +2,24 @@
   "type": "factorio",
   "display": "Factorio",
   "data": {
+    "version": {
+      "desc": "Which Factorio version should be installed",
+      "display": "Version",
+      "internal": false,
+      "required": true,
+      "value": "",
+      "type": "option",
+      "options": [
+        {
+          "value": "stable",
+          "display": "Stable"
+        },
+        {
+          "value": "latest",
+          "display": "Latest"
+        }
+      ]
+    },
     "save": {
       "value": "saves/default.zip",
       "required": true,
@@ -36,7 +54,7 @@
     {
       "type": "command",
       "commands": [
-        "curl -L -o factorio.tar.xz https://www.factorio.com/get-download/stable/headless/linux64",
+        "curl -L -o factorio.tar.xz https://www.factorio.com/get-download/${version}/headless/linux64",
         "mkdir factorio",
         "tar --no-same-owner -xvf factorio.tar.xz",
         "cp factorio/data/server-settings.example.json factorio/data/server-settings.json",

--- a/factorio/factorio.json
+++ b/factorio/factorio.json
@@ -36,7 +36,7 @@
     {
       "type": "command",
       "commands": [
-        "curl -L -o factorio.tar.xz https://www.factorio.com/get-download/latest/headless/linux64",
+        "curl -L -o factorio.tar.xz https://www.factorio.com/get-download/stable/headless/linux64",
         "mkdir factorio",
         "tar --no-same-owner -xvf factorio.tar.xz",
         "cp factorio/data/server-settings.example.json factorio/data/server-settings.json",


### PR DESCRIPTION
Accordingly [Factorio docs](https://factorio.com/download): "If you are running a server, you can use this link to always download the latest stable version."