### PR TITLE
Lib32gcc1 rename in debian 11

### DIFF
--- a/gmod/README.md
+++ b/gmod/README.md
@@ -8,7 +8,8 @@ Install this to use SteamCMD:
 sudo apt install lib32gcc1 lib32stdc++6
 
 ```
-- On newer ubuntu versions, package `lib32gcc1` might not be aviable. In that case, install this:
+- On newer ubuntu versions, package `lib32gcc1` might not be available. In that case, install this:
+
    ```sudo apt install lib32gcc-s1 lib32stdc++6```
 
 Install this for Gmod:

--- a/gmod/README.md
+++ b/gmod/README.md
@@ -1,10 +1,22 @@
+
 ## Garry's Mod
+
 Install this to use SteamCMD:
+
 ```
+
 sudo apt install lib32gcc1 lib32stdc++6
+
 ```
+- On newer ubuntu versions, package `lib32gcc1` might not be aviable. In that case, install this:
+   ```sudo apt install lib32gcc-s1 lib32stdc++6```
+
 Install this for Gmod:
+
 ```
+
 sudo apt install libncurses5:i386
+
 ```
+
 ## This only supports Linux.


### PR DESCRIPTION
As per [this](https://discordapp.com/channels/291396338141364226/291396338141364226/1137472550272778300) message in #support, and [this](https://github.com/Ysurac/openmptcprouter/issues/2333#issuecomment-1102116417) GitHub thread, I added a notice for users of distros based on Debian >10