### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/minecraft-bungeecord/minecraft-bungeecord-docker.json
+++ b/minecraft-bungeecord/minecraft-bungeecord-docker.json
@@ -28,7 +28,7 @@
     "motd": {
       "value": "A BungeeCord Server &9hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-bungeecord/minecraft-bungeecord.json
+++ b/minecraft-bungeecord/minecraft-bungeecord.json
@@ -28,7 +28,7 @@
     "motd": {
       "value": "A BungeeCord Server &9hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     },

--- a/minecraft-fabric/minecraft-fabric-docker.json
+++ b/minecraft-fabric/minecraft-fabric-docker.json
@@ -39,7 +39,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel"

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -39,7 +39,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel"

--- a/minecraft-forge-legacy/minecraft-forge-legacy-docker.json
+++ b/minecraft-forge-legacy/minecraft-forge-legacy-docker.json
@@ -80,7 +80,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-forge-legacy/minecraft-forge-legacy.json
+++ b/minecraft-forge-legacy/minecraft-forge-legacy.json
@@ -86,7 +86,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-forge/minecraft-forge-docker.json
+++ b/minecraft-forge/minecraft-forge-docker.json
@@ -43,7 +43,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -49,7 +49,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-ftb-fabric/minecraft-ftb-fabric.json
+++ b/minecraft-ftb-fabric/minecraft-ftb-fabric.json
@@ -91,7 +91,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server hosted on PufferPanel"

--- a/minecraft-ftb-legacy/minecraft-ftb-legacy-docker.json
+++ b/minecraft-ftb-legacy/minecraft-ftb-legacy-docker.json
@@ -28,7 +28,7 @@
     "motd": {
       "value": "A Minecraft Server hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     },

--- a/minecraft-ftb-legacy/minecraft-ftb-legacy.json
+++ b/minecraft-ftb-legacy/minecraft-ftb-legacy.json
@@ -28,7 +28,7 @@
     "motd": {
       "value": "A Minecraft Server hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     },

--- a/minecraft-ftb/minecraft-ftb-docker.json
+++ b/minecraft-ftb/minecraft-ftb-docker.json
@@ -49,7 +49,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server hosted on PufferPanel"

--- a/minecraft-ftb/minecraft-ftb.json
+++ b/minecraft-ftb/minecraft-ftb.json
@@ -49,7 +49,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server hosted on PufferPanel"

--- a/minecraft-magma/minecraft-magma-docker.json
+++ b/minecraft-magma/minecraft-magma-docker.json
@@ -34,7 +34,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",

--- a/minecraft-magma/minecraft-magma.json
+++ b/minecraft-magma/minecraft-magma.json
@@ -34,7 +34,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",

--- a/minecraft-modpack-gtnh/minecraft-modpack-gtnh-docker.json
+++ b/minecraft-modpack-gtnh/minecraft-modpack-gtnh-docker.json
@@ -77,7 +77,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A \\u00a7eGTNH \\u00a7rServer hosted on \\u00a7bPufferPanel"

--- a/minecraft-modpack-gtnh/minecraft-modpack-gtnh.json
+++ b/minecraft-modpack-gtnh/minecraft-modpack-gtnh.json
@@ -81,7 +81,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A \\u00a7eGTNH \\u00a7rServer hosted on \\u00a7bPufferPanel"

--- a/minecraft-mohist/minecraft-mohist-docker.json
+++ b/minecraft-mohist/minecraft-mohist-docker.json
@@ -43,7 +43,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Mohist Server\\n\\u00A79 hosted on PufferPanel",

--- a/minecraft-mohist/minecraft-mohist.json
+++ b/minecraft-mohist/minecraft-mohist.json
@@ -43,7 +43,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Mohist Server\\n\\u00A79 hosted on PufferPanel",

--- a/minecraft-paper/minecraft-paper-docker.json
+++ b/minecraft-paper/minecraft-paper-docker.json
@@ -50,7 +50,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -50,7 +50,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     },

--- a/minecraft-purpur/minecraft-purpur-docker.json
+++ b/minecraft-purpur/minecraft-purpur-docker.json
@@ -50,7 +50,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-purpur/minecraft-purpur.json
+++ b/minecraft-purpur/minecraft-purpur.json
@@ -50,7 +50,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     },

--- a/minecraft-quilt/minecraft-quilt.json
+++ b/minecraft-quilt/minecraft-quilt.json
@@ -33,7 +33,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel"

--- a/minecraft-spigot/minecraft-spigot-docker.json
+++ b/minecraft-spigot/minecraft-spigot-docker.json
@@ -43,7 +43,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -43,7 +43,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     },

--- a/minecraft-vanilla/minecraft-vanilla-docker.json
+++ b/minecraft-vanilla/minecraft-vanilla-docker.json
@@ -43,7 +43,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     }

--- a/minecraft-vanilla/minecraft-vanilla.json
+++ b/minecraft-vanilla/minecraft-vanilla.json
@@ -43,7 +43,7 @@
     "motd": {
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "required": true,
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "internal": false
     },

--- a/minecraft-velocity/minecraft-velocity-docker.json
+++ b/minecraft-velocity/minecraft-velocity-docker.json
@@ -34,7 +34,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Velocity proxy &9hosted on PufferPanel"

--- a/minecraft-velocity/minecraft-velocity.json
+++ b/minecraft-velocity/minecraft-velocity.json
@@ -34,7 +34,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Velocity proxy &9hosted on PufferPanel"

--- a/minecraft-waterfall/minecraft-waterfall-docker.json
+++ b/minecraft-waterfall/minecraft-waterfall-docker.json
@@ -25,7 +25,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Waterfall Server &9hosted on PufferPanel"

--- a/minecraft-waterfall/minecraft-waterfall.json
+++ b/minecraft-waterfall/minecraft-waterfall.json
@@ -25,7 +25,7 @@
     },
     "motd": {
       "type": "string",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "display": "MOTD message of the day",
       "required": true,
       "value": "A Waterfall Server &9hosted on PufferPanel"


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.