### PR TITLE
Update Quilt installer download url

### DIFF
--- a/minecraft-quilt/minecraft-quilt.json
+++ b/minecraft-quilt/minecraft-quilt.json
@@ -60,7 +60,7 @@
     },
     {
       "files": [
-        "https://maven.quiltmc.org/repository/release/org/quiltmc/quilt-installer/latest/quilt-installer-latest.jar"
+        "https://quiltmc.org/api/v1/download-latest-installer/java-universal"
       ],
       "type": "download"
     },


### PR DESCRIPTION
The URL to download the Quilt installer in the minecraft-quilt template was broken which meant you couldn't use it, this fixes it