### PR TITLE
OpenTTD template

### DIFF
--- a/openttd/README.md
+++ b/openttd/README.md
@@ -1,0 +1,2 @@
+**Game Version** is as per https://www.openttd.org/downloads/openttd-releases/latest
+**OpenGFX Version** is as per https://www.openttd.org/downloads/opengfx-releases/latest

--- a/openttd/openttd.json
+++ b/openttd/openttd.json
@@ -1,0 +1,85 @@
+{
+  "name": "openttd",
+  "display": "OpenTTD",
+  "type": "other",
+  "install": [
+    {
+      "target": "./download",
+      "type": "mkdir"
+    },
+    {
+      "target": "./.local/share/openttd",
+      "type": "mkdir"
+    },
+    {
+      "files": [
+        "https://cdn.openttd.org/openttd-releases/${Game_Version}/openttd-${Game_Version}-linux-generic-amd64.tar.xz",
+        "https://cdn.openttd.org/opengfx-releases/${GFX_Version}/opengfx-${GFX_Version}-all.zip"
+      ],
+      "type": "download"
+    },
+    {
+      "source": "./openttd-${Game_Version}-linux-generic-amd64.tar.xz",
+      "target": "./download/",
+      "type": "move"
+    },
+    {
+      "source": "./opengfx-${GFX_Version}-all.zip",
+      "target": "./download/",
+      "type": "move"
+    },
+    {
+      "commands": [
+        "tar -xf ./download/openttd-${Game_Version}-linux-generic-amd64.tar.xz -C ./download/",
+        "unzip ./download/opengfx-${GFX_Version}-all.zip -d ./download/",
+        "tar -xf ./download/opengfx-${GFX_Version}.tar -C ./download/"
+      ],
+      "type": "command"
+    },
+    {
+      "commands": [
+        "mv ./download/openttd-${Game_Version}-linux-generic-amd64 ./download/openttd",
+        "mv ./download/opengfx-${GFX_Version} ./download/baseset",
+        "cp -ar ./download/baseset ./.local/share/openttd",
+        "cp -ar ./download/openttd ./",
+        "rm -rf ./download/openttd ./download/baseset ./download/opengfx-${GFX_Version}.tar"
+      ],
+      "type": "command"
+    }
+  ],
+  "run": {
+    "stop": "exit",
+    "command": "./openttd -D",
+    "workingDirectory": "./openttd",
+    "pre": [],
+    "post": [],
+    "environmentVars": {}
+  },
+  "data": {
+    "GFX_Version": {
+      "type": "string",
+      "display": "OpenGFX Version",
+      "required": true,
+      "value": "7.1",
+      "userEdit": true,
+      "desc": "As per the available release on https://www.openttd.org/downloads/opengfx-releases/latest"
+    },
+    "Game_Version": {
+      "type": "string",
+      "display": "Game Version",
+      "required": true,
+      "value": "13.4",
+      "userEdit": true,
+      "desc": "As per the available release on https://www.openttd.org/downloads/openttd-releases/latest"
+    }
+  },
+  "environment": {
+    "type": "tty"
+  },
+  "supportedEnvironments": [
+    {
+      "type": "tty"
+    }
+  ],
+  "requirements": {}
+}


### PR DESCRIPTION
This template supports OpenTTD.

It downloads the user-specified versions of the game files & the OpenGFX graphics (don't ask me why the server needs the graphics files, I don't know. It won't run without them, though), places them in the appropriate locations, and does so in a way that should be in-place-update-friendly for new releases.

Unfortunately I was unable to get it to properly support setting config values such as port during install. This is due to two combined factors:
- The server doesn't *appear* to read partial config files. You either have a *complete* config file, or the server loads default values.
- The config file is extremely long, and I don't believe that it's good practice for a server management tool to be responsible for maintaining up-to-date copies of config files, simply to make changing a handful of values more convenient.