### PR TITLE
fix Minecraft fabric versioning

### DIFF
--- a/minecraft-fabric/minecraft-fabric-docker.json
+++ b/minecraft-fabric/minecraft-fabric-docker.json
@@ -14,7 +14,7 @@
       "desc": "Version of Minecraft to install (Oldest fabric version is 1.14)",
       "display": "GAME VERSION",
       "required": true,
-      "value": "1.20.1"
+      "value": "1.20.2"
     },
     "loader-version": {
       "type": "string",

--- a/minecraft-fabric/minecraft-fabric-docker.json
+++ b/minecraft-fabric/minecraft-fabric-docker.json
@@ -16,13 +16,6 @@
       "required": true,
       "value": "1.20.2"
     },
-    "loader-version": {
-      "type": "string",
-      "desc": "Version of Fabric Loader to install",
-      "display": "LOADER VERSION",
-      "required": true,
-      "value": "0.15.0"
-    },
     "ip": {
       "type": "string",
       "desc": "What IP to bind server to",
@@ -58,7 +51,7 @@
     },
     {
       "commands": [
-        "java -jar fabric-installer.jar server -mcversion ${game-version} -loader ${loader-version} -downloadMinecraft -noprofile"
+        "java -jar fabric-installer.jar server -mcversion ${game-version} -downloadMinecraft -noprofile"
       ],
       "type": "command"
     },

--- a/minecraft-fabric/minecraft-fabric-docker.json
+++ b/minecraft-fabric/minecraft-fabric-docker.json
@@ -21,7 +21,7 @@
       "desc": "Version of Fabric Loader to install",
       "display": "LOADER VERSION",
       "required": true,
-      "value": "latest"
+      "value": "0.15.0"
     },
     "ip": {
       "type": "string",


### PR DESCRIPTION
The fabric api no longer supports "latest" as a loader version. Defaulting to a specific version instead.

Resolves #235 