### PR TITLE
Add template for Terraria Vanilla arm64

### DIFF
--- a/terraria-vanilla-arm64/README.md
+++ b/terraria-vanilla-arm64/README.md
@@ -1,0 +1,6 @@
+Terarria Vanilla Template - made for linux arm64
+
+You need to have unzip installed, see here how you can install it on Linux: https://command-not-found.com/unzip
+
+Also you need to install mono for your system: https://www.mono-project.com/download/stable/#download-lin
+We suggest installing "mono-complete" (run "sudo apt install mono-complete" after adding the appropiate apt repo for your system)

--- a/terraria-vanilla-arm64/terraria-vanilla-arm64.json
+++ b/terraria-vanilla-arm64/terraria-vanilla-arm64.json
@@ -1,0 +1,225 @@
+{
+  "type": "terraria-arm64",
+  "display": "Terraria - Vanila (ARM64)",
+  "data": {
+    "abr": {
+      "type": "string",
+      "desc": "Sets the announcementbox text messaging range in pixels, -1 for serverwide announcements.",
+      "display": "announcementbox-range",
+      "required": true,
+      "value": "-1"
+    },
+    "backups": {
+      "type": "string",
+      "desc": "Sets the number of rolling world backups to keep",
+      "display": "Backups",
+      "required": true,
+      "value": "2"
+    },
+    "ban": {
+      "type": "string",
+      "desc": "Name of the banlist file",
+      "display": "Banlist",
+      "required": true,
+      "value": "banlist.txt"
+    },
+    "difficulty": {
+      "type": "string",
+      "desc": "This can not be changed after the world was generated - Options: 0 - (normal), 1 - (expert), 2 - (master), 3 - (journey)",
+      "display": "Difficulty",
+      "required": true,
+      "value": "0"
+    },
+    "disableannouncementbox": {
+      "type": "string",
+      "desc": "Disables the text announcements Announcement Box makes when pulsed from wire. - leave blank to let them enabled - or set it to `-disableannouncementbox` to disable it",
+      "display": "announcementbox",
+      "value": ""
+    },
+    "ip": {
+      "type": "string",
+      "desc": "Sets the IP address for the server to listen on - 0.0.0.0 means every possible IP",
+      "display": "IP",
+      "required": true,
+      "value": "0.0.0.0"
+    },
+    "lang": {
+      "type": "string",
+      "desc": "Please use the short lang code - English=en-US, German=de-DE, Italian=it-IT, French=fr-FR, Spanish=es-ES, Russian=ru-RU, Chinese=zh-Hans, Portuguese=pt-BR, Polish=pl-PL",
+      "display": "Language",
+      "required": true,
+      "value": "en-US"
+    },
+    "motd": {
+      "type": "string",
+      "desc": "Set the message of the day",
+      "display": "motd",
+      "required": true,
+      "value": "Hello!"
+    },
+    "npcs": {
+      "type": "string",
+      "desc": "Reduces enemy skipping but increases bandwidth usage. The lower the number the less skipping will happen, but more data is sent. 0 is off.",
+      "display": "npcstream",
+      "required": true,
+      "value": "60"
+    },
+    "password": {
+      "type": "string",
+      "desc": "Server Password - leave blank for none",
+      "display": "Password",
+      "required": true,
+      "value": ""
+    },
+    "players": {
+      "type": "string",
+      "desc": "Max Players",
+      "display": "Players",
+      "required": true,
+      "value": "4"
+    },
+    "port": {
+      "type": "string",
+      "desc": "What port to bind the server to",
+      "display": "Port",
+      "required": true,
+      "value": "7777"
+    },
+    "priority": {
+      "type": "string",
+      "desc": "Set priority 0:Realtime, 1:High, 2:Above-Normal, 3:Normal, 4:Below-Normal, 5:Idle",
+      "display": "priority",
+      "required": true,
+      "value": "1"
+    },
+    "secure": {
+      "type": "string",
+      "desc": "Enable cheat protection = 1 and disable = 0",
+      "display": "secure",
+      "required": true,
+      "value": "1"
+    },
+    "seed": {
+      "type": "string",
+      "desc": "This can not be changed after the world was generated - Seed of the World",
+      "display": "Seed",
+      "required": true,
+      "value": "VeryGoodStartingSeed"
+    },
+    "size": {
+      "type": "string",
+      "desc": "This can not be changed after the world was generated - World Size (1-3 - 3 is biggest)",
+      "display": "World-Size",
+      "required": true,
+      "value": "3"
+    },
+    "sl": {
+      "type": "string",
+      "desc": "Reduces maximum liquids moving at the same time. If enabled may reduce lags but liquids may take longer to settle.",
+      "display": "maximum liquids moving",
+      "required": true,
+      "value": "1"
+    },
+    "steam": {
+      "type": "string",
+      "desc": "Enables Steam Support - leave blank to disable - or set it to `-steam` to enable it",
+      "display": "Steam",
+      "value": "-steam"
+    },
+    "upnp": {
+      "type": "string",
+      "desc": "Enable upnp = 1 and disable = 0",
+      "display": "upnp",
+      "required": true,
+      "value": "1"
+    },
+    "version": {
+      "type": "string",
+      "desc": "Server Version",
+      "display": "Server Version (Set this to the latest server version) - It is the current terraria Version without the Points (Client Version: 1.4.3.2 -> Server Version: 1432)",
+      "required": true,
+      "value": "1449"
+    },
+    "world": {
+      "type": "string",
+      "desc": "Name of your World",
+      "display": "World-Name",
+      "required": true,
+      "value": "Terraria-World-1"
+    },
+    "wp": {
+      "type": "string",
+      "desc": "Name of the world folder",
+      "display": "Worldpath",
+      "required": true,
+      "value": "worlds"
+    }
+  },
+  "install": [
+    {
+      "files": [
+        "https://terraria.org/api/download/pc-dedicated-server/terraria-server-${version}.zip"
+      ],
+      "type": "download"
+    },
+    {
+      "commands": [
+        "unzip terraria-server-${version}.zip",
+        "mkdir -p ./server",
+        "cp -r ./${version}/Linux/. ./server",
+        "mkdir -p ./${wp}",
+        "rm terraria-server-${version}.zip",
+        "rm -r ${version}"
+      ],
+      "type": "command"
+    },
+    {
+      "commands": [
+        "rm -f ./server/System.Configuration.dll",
+        "rm -f ./server/System.Core.dll",
+        "rm -f ./server/System.Data.dll",
+        "rm -f ./server/System.dll",
+        "rm -f ./server/System.Drawing.dll",
+        "rm -f ./server/System.Numerics.dll",
+        "rm -f ./server/System.Runtime.Serialization.dll",
+        "rm -f ./server/System.Security.dll",
+        "rm -f ./server/System.Windows.Forms.dll",
+        "rm -f ./server/System.Windows.Forms.dll.config",
+        "rm -f ./server/System.Xml.dll",
+        "rm -f ./server/System.Xml.Linq.dll",
+        "rm -f ./server/Mono.Posix.dll",
+        "rm -f ./server/Mono.Security.dll",
+        "rm -f ./server/monoconfig",
+        "rm -f ./server/mscorlib.dll"
+      ],
+      "type": "command"
+    },
+    {
+      "target": "serverconfig.txt",
+      "text": "world=./${wp}/${world}.wld\nautocreate=${size}\nseed=${seed}\nworldname=${world}\ndifficulty=${difficulty}\nmaxplayers=${players}\nport=${port}\npassword=${password}\nmotd=${motd}\nworldpath=./${wp}\nbanlist=./${ban}\nsecure=${secure}\nlanguage=${lang}\nupnp=${upnp}\nnpcstream=${npcs}\npriority=${priority}\nslowliquids=${sl}\nworldrollbackstokeep=${backups}",
+      "type": "writefile"
+    }
+  ],
+  "run": {
+    "command": "mono --server --gc=sgen -O=all ./server/TerrariaServer.exe -ip ${ip} ${steam} ${disableannouncementbox} -announcementboxrange ${abr} -config ./serverconfig.txt",
+    "stop": "exit",
+    "pre": [
+      {
+        "target": "serverconfig.txt",
+        "text": "world=./${wp}/${world}.wld\nautocreate=${size}\nseed=${seed}\nworldname=${world}\ndifficulty=${difficulty}\nmaxplayers=${players}\nport=${port}\npassword=${password}\nmotd=${motd}\nworldpath=./${wp}\nbanlist=./${ban}\nsecure=${secure}\nlanguage=${lang}\nupnp=${upnp}\nnpcstream=${npcs}\npriority=${priority}\nslowliquids=${sl}\nworldrollbackstokeep=${backups}",
+        "type": "writefile"
+      }
+    ]
+  },
+  "environment": {
+    "type": "tty"
+  },
+  "requirements": {
+    "binaries": [
+      "unzip",
+      "mono"
+    ],
+    "os": "linux",
+    "arch": "arm64"
+  }
+}


### PR DESCRIPTION
Add template for Terraria vanilla on arm64. 
For this the user has to install mono on their systems first => So it's a little bit advanced to setup

Based on: 
https://terraria.fandom.com/wiki/Server
https://www.reddit.com/r/Terraria/comments/gl1ahw/comment/fqv3qis/?utm_source=share&utm_medium=web2x

Changes compared to Terraria vanilla template:

General:
- type "terraria" -> "terraria-arm64"
- display name
- "mono" listed as required binary
- arch: arm64 instead of amd64

Install:
- Remove "chmod +x" statemants (not needed)
- Add rm commands to delete most of the dlls delivered with Terraria Server download (as described in Terraria Wiki and Reddit)

Run
- "mono --server --gc=sgen -O=all ./server/TerrariaServer.exe <options>" instead of "./server/TerrariaServer <options>"

Paths to config, world folder, etc:
Due to new run command, working directory is now the base server directory and not "./server" => Therefore paths in run options and within serverconfig.txt needed to be adjusted

The remaining template (especially to data/config stuff) stays untouched

I'm looking forward to hear your feedback on this :)
And great work by the way - I really enjoy using pufferplanel