### PR TITLE
Update minecraft-bedrock.json to newest version

### DIFF
--- a/minecraft-bedrock/minecraft-bedrock.json
+++ b/minecraft-bedrock/minecraft-bedrock.json
@@ -3,7 +3,7 @@
   "display": "Minecraft Bedrock",
   "data": {
     "version": {
-      "value": "1.20.12",
+      "value": "1.20.51.01",
       "required": true,
       "desc": "Version of the Minecraft Bedrock Server to use",
       "display": "Bedrock Version",


### PR DESCRIPTION
On 2024-01-01 the latest version of the Minecraft Bedrock server is 1.20.51.01
This is just a simple update of the template json to make it work with the latest version