### PR TITLE
Fixed/added stop codes in discord templates

### DIFF
--- a/discord-jda/discord-jda-docker.json
+++ b/discord-jda/discord-jda-docker.json
@@ -12,7 +12,8 @@
     }
   },
   "run": {
-    "command": "java -jar ${jar}"
+    "command": "java -jar ${jar}",
+    "stopCode": 2
   },
   "environment": {
     "image": "openjdk",

--- a/discord-jda/discord-jda.json
+++ b/discord-jda/discord-jda.json
@@ -12,7 +12,8 @@
     }
   },
   "run": {
-    "command": "java -jar ${jar}"
+    "command": "java -jar ${jar}",
+    "stopCode": 2
   },
   "environment": {
     "type": "standard"

--- a/discord-js/discord-js-docker.json
+++ b/discord-js/discord-js-docker.json
@@ -20,7 +20,7 @@
   ],
   "run": {
     "command": "node ./${bot-js-file}",
-    "stop": "stop"
+    "stopCode": 2
   },
   "environment": {
     "type": "docker",

--- a/discord-js/discord-js.json
+++ b/discord-js/discord-js.json
@@ -20,7 +20,7 @@
   ],
   "run": {
     "command": "node ./${bot-js-file}",
-    "stop": "stop"
+    "stopCode": 2
   },
   "environment": {
     "type": "standard"

--- a/discord-py/discord-py-docker.json
+++ b/discord-py/discord-py-docker.json
@@ -27,7 +27,7 @@
   ],
   "run": {
     "command": "python3 ${bot-py-file}",
-    "stop": "stop"
+    "stopCode": 2
   },
   "environment": {
     "type": "docker",

--- a/discord-py/discord-py.json
+++ b/discord-py/discord-py.json
@@ -27,7 +27,7 @@
   ],
   "run": {
     "command": "python3 ${bot-py-file}",
-    "stop": "stop"
+    "stopCode": 2
   },
   "environment": {
     "type": "standard"


### PR DESCRIPTION
Before, the templates were just sending the `stop` command to the console. That wouldn't work on 99% of bots.
So, instead, I added the `SIGINT` signal 2, equivalent to a CTRL+C