### PR TITLE
Add support for MinecraftForge legacy, 1.16 and below. v3

### DIFF
--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -276,6 +276,12 @@
       "target": "server.jar"
     },
     {
+      "if": "modlauncher == 'forge' && file_exists('forge-' + forgebuild + '.jar')",
+      "type": "move",
+      "source": "forge-${forgebuild}.jar",
+      "target": "server.jar"
+    },
+    {
       "if": "modlauncher == 'magma'",
       "type": "download",
       "files": [


### PR DESCRIPTION
Adding support for older version of minecraft forge my changing the server file name to "server.jar".
Previous version only checks for shim.