### PR TITLE
Resolves Minecraft - java edition: template for paper using wrong binary name

### DIFF
--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -317,7 +317,7 @@
     {
       "if": "modlauncher == 'paper'",
       "type": "move",
-      "target": "paper.jar",
+      "target": "server.jar",
       "source": "paper-*.jar"
     },
     {


### PR DESCRIPTION
Solves the startup of a paper server
because no special handling is needed for "paper*.jar" renaming to "server.jar" instead of "paper.jar" is ok

Resolves: [1312](https://github.com/pufferpanel/pufferpanel/issues/1312)