### PR TITLE
Update minecraft-mohist-docker.json versions URL

### DIFF
--- a/minecraft-mohist/minecraft-mohist-docker.json
+++ b/minecraft-mohist/minecraft-mohist-docker.json
@@ -35,7 +35,7 @@
     },
     "mohist-version": {
       "type": "string",
-      "desc": "Mohist version to install (may be located <a href='https://mohistmc.com/download/' target='_blank'>here</a>).",
+      "desc": "Mohist version to install (may be located <a href='https://mohistmc.com/downloadSoftware?project=mohist' target='_blank'>here</a>).",
       "display": "Mohist Version",
       "required": true,
       "value": "latest",


### PR DESCRIPTION
`https://mohistmc.com/download` leads to a 404. The correct URL to list Mohist versions is `https://mohistmc.com/downloadSoftware?project=mohist`