### PR TITLE
Bump Minecraft Default Java Version Value to 21 (Ensure Compatibility with 1.20.5+) [PUFFERPANEL'S TEMURIN DOCKER IMAGE NEEDS UPDATE TO SUPPORT JDK 21 FIRST, unless it uses the original Temurin image?]

### DIFF
--- a/minecraft-autoplug/minecraft-autoplug-docker.json
+++ b/minecraft-autoplug/minecraft-autoplug-docker.json
@@ -63,6 +63,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-autoplug/minecraft-autoplug.json
+++ b/minecraft-autoplug/minecraft-autoplug.json
@@ -43,7 +43,7 @@
       "desc": "Version of Java to use",
       "display": "Java Version",
       "required": true,
-      "value": "17"
+      "value": "21"
     }
   },
   "install": [

--- a/minecraft-bungeecord/minecraft-bungeecord-docker.json
+++ b/minecraft-bungeecord/minecraft-bungeecord-docker.json
@@ -50,6 +50,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-bungeecord/minecraft-bungeecord.json
+++ b/minecraft-bungeecord/minecraft-bungeecord.json
@@ -36,7 +36,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-fabric/minecraft-fabric-docker.json
+++ b/minecraft-fabric/minecraft-fabric-docker.json
@@ -90,6 +90,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-fabric/minecraft-fabric.json
+++ b/minecraft-fabric/minecraft-fabric.json
@@ -48,7 +48,7 @@
       "type": "integer",
       "desc": "Version of Java to use (If you play 1.16.5 or lower use 8)",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-forge-legacy/minecraft-forge-legacy-docker.json
+++ b/minecraft-forge-legacy/minecraft-forge-legacy-docker.json
@@ -52,7 +52,7 @@
           "display": "Any other version"
         },
         {
-          "value": "-mc212",
+          "value": "-mc172",
           "display": "Minecraft 1.7.2"
         },
         {

--- a/minecraft-forge-legacy/minecraft-forge-legacy-docker.json
+++ b/minecraft-forge-legacy/minecraft-forge-legacy-docker.json
@@ -52,7 +52,7 @@
           "display": "Any other version"
         },
         {
-          "value": "-mc172",
+          "value": "-mc212",
           "display": "Minecraft 1.7.2"
         },
         {

--- a/minecraft-forge-legacy/minecraft-forge-legacy.json
+++ b/minecraft-forge-legacy/minecraft-forge-legacy.json
@@ -58,7 +58,7 @@
           "display": "Any other version"
         },
         {
-          "value": "-mc212",
+          "value": "-mc172",
           "display": "Minecraft 1.7.2"
         },
         {

--- a/minecraft-forge-legacy/minecraft-forge-legacy.json
+++ b/minecraft-forge-legacy/minecraft-forge-legacy.json
@@ -58,7 +58,7 @@
           "display": "Any other version"
         },
         {
-          "value": "-mc172",
+          "value": "-mc212",
           "display": "Minecraft 1.7.2"
         },
         {

--- a/minecraft-forge/minecraft-forge-docker.json
+++ b/minecraft-forge/minecraft-forge-docker.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "MinecraftForge 1.17+ - Minecraft (Docker)",
+  "display": "MinecraftForge 1.21+ - Minecraft (Docker)",
   "data": {
     "memory": {
       "value": "1024",
@@ -77,6 +77,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-forge/minecraft-forge-docker.json
+++ b/minecraft-forge/minecraft-forge-docker.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "MinecraftForge 1.21+ - Minecraft (Docker)",
+  "display": "MinecraftForge 1.17+ - Minecraft (Docker)",
   "data": {
     "memory": {
       "value": "1024",

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "MinecraftForge 1.21+ - Minecraft",
+  "display": "MinecraftForge 1.17+ - Minecraft",
   "data": {
     "memory": {
       "value": "1024",

--- a/minecraft-forge/minecraft-forge.json
+++ b/minecraft-forge/minecraft-forge.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "MinecraftForge 1.17+ - Minecraft",
+  "display": "MinecraftForge 1.21+ - Minecraft",
   "data": {
     "memory": {
       "value": "1024",
@@ -41,7 +41,7 @@
       "internal": false
     },
     "javaversion": {
-      "value": "17",
+      "value": "21",
       "required": true,
       "desc": "Version of Java to use",
       "display": "Java Version"

--- a/minecraft-ftb-fabric/minecraft-ftb-fabric.json
+++ b/minecraft-ftb-fabric/minecraft-ftb-fabric.json
@@ -63,7 +63,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     },
     "memory": {

--- a/minecraft-ftb/minecraft-ftb-docker.json
+++ b/minecraft-ftb/minecraft-ftb-docker.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "FTB - Forge 1.17+ (Docker)",
+  "display": "FTB - Forge 1.21+ (Docker)",
   "data": {
     "eula": {
       "type": "boolean",
@@ -100,7 +100,7 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   },
   "requirements": {
     "os": "linux",

--- a/minecraft-ftb/minecraft-ftb-docker.json
+++ b/minecraft-ftb/minecraft-ftb-docker.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "FTB - Forge 1.21+ (Docker)",
+  "display": "FTB - Forge 1.17+ (Docker)",
   "data": {
     "eula": {
       "type": "boolean",

--- a/minecraft-ftb/minecraft-ftb.json
+++ b/minecraft-ftb/minecraft-ftb.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "FTB - Forge 1.21+",
+  "display": "FTB - Forge 1.17+",
   "data": {
     "eula": {
       "type": "boolean",

--- a/minecraft-ftb/minecraft-ftb.json
+++ b/minecraft-ftb/minecraft-ftb.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft-java",
-  "display": "FTB - Forge 1.17+",
+  "display": "FTB - Forge 1.21+",
   "data": {
     "eula": {
       "type": "boolean",
@@ -69,7 +69,7 @@
       "value": ""
     },
     "javaversion": {
-      "value": "17",
+      "value": "21",
       "required": true,
       "desc": "Version of Java to use",
       "display": "Java Version"

--- a/minecraft-magma/minecraft-magma-docker.json
+++ b/minecraft-magma/minecraft-magma-docker.json
@@ -86,6 +86,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-magma/minecraft-magma.json
+++ b/minecraft-magma/minecraft-magma.json
@@ -60,7 +60,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-modpack-gtnh/minecraft-modpack-gtnh-docker.json
+++ b/minecraft-modpack-gtnh/minecraft-modpack-gtnh-docker.json
@@ -5,7 +5,7 @@
   "install": [
     {
       "files": [
-        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_17-19.zip"
+        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
       ],
       "type": "download"
     },
@@ -17,7 +17,7 @@
     },
     {
       "commands": [
-        "unzip -o *_${gtnh-ver}_Server_Java_17-19.zip"
+        "unzip -o *_${gtnh-ver}_Server_Java_21-19.zip"
       ],
       "type": "command"
     },
@@ -33,7 +33,7 @@
     },
     {
       "commands": [
-        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_17-19.zip"
+        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
       ],
       "type": "command"
     }
@@ -92,12 +92,12 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   },
   "supportedEnvironments": [
     {
       "type": "docker",
-      "image": "eclipse-temurin:17"      
+      "image": "eclipse-temurin:21"      
     }
   ],
   "requirements": {

--- a/minecraft-modpack-gtnh/minecraft-modpack-gtnh-docker.json
+++ b/minecraft-modpack-gtnh/minecraft-modpack-gtnh-docker.json
@@ -5,7 +5,7 @@
   "install": [
     {
       "files": [
-        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
+        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_17-21.zip"
       ],
       "type": "download"
     },
@@ -33,7 +33,7 @@
     },
     {
       "commands": [
-        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
+        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_17-21.zip"
       ],
       "type": "command"
     }
@@ -56,10 +56,10 @@
     },
     "gtnh-ver": {
       "type": "string",
-      "desc": "May be located <a href='http://downloads.gtnewhorizons.com/ServerPacks/'>here</a>. E.g. \"2.2.9\" or \"2.3.0-RC-3\".",
+      "desc": "May be located <a href='http://downloads.gtnewhorizons.com/ServerPacks/'>here</a>. E.g. \"2.4.0\" or \"2.5.0-RC-1\".",
       "display": "GT: New Horizons version",
       "required": true,
-      "value": "2.3.0"
+      "value": "2.4.0"
     },
     "ip": {
       "type": "string",
@@ -97,7 +97,7 @@
   "supportedEnvironments": [
     {
       "type": "docker",
-      "image": "eclipse-temurin:21"      
+      "image": "eclipse-temurin:21"
     }
   ],
   "requirements": {

--- a/minecraft-modpack-gtnh/minecraft-modpack-gtnh.json
+++ b/minecraft-modpack-gtnh/minecraft-modpack-gtnh.json
@@ -5,7 +5,7 @@
   "install": [
     {
       "files": [
-        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
+        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_17-21.zip"
       ],
       "type": "download"
     },
@@ -17,7 +17,7 @@
     },
     {
       "commands": [
-        "unzip -o *_${gtnh-ver}_Server_Java_21-19.zip"
+        "unzip -o *_${gtnh-ver}_Server_Java_17-21.zip"
       ],
       "type": "command"
     },
@@ -33,7 +33,7 @@
     },
     {
       "commands": [
-        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
+        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_17-21.zip"
       ],
       "type": "command"
     },
@@ -60,10 +60,10 @@
     },
     "gtnh-ver": {
       "type": "string",
-      "desc": "May be located <a href='http://downloads.gtnewhorizons.com/ServerPacks/'>here</a>. E.g. \"2.2.9\" or \"2.3.0-RC-3\".",
+      "desc": "May be located <a href='http://downloads.gtnewhorizons.com/ServerPacks/'>here</a>. E.g. \"2.4.0\" or \"2.5.0-RC-1\".",
       "display": "GT: New Horizons version",
       "required": true,
-      "value": "2.3.0"
+      "value": "2.4.0"
     },
     "ip": {
       "type": "string",

--- a/minecraft-modpack-gtnh/minecraft-modpack-gtnh.json
+++ b/minecraft-modpack-gtnh/minecraft-modpack-gtnh.json
@@ -5,7 +5,7 @@
   "install": [
     {
       "files": [
-        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_17-19.zip"
+        "http://downloads.gtnewhorizons.com/ServerPacks/GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
       ],
       "type": "download"
     },
@@ -17,7 +17,7 @@
     },
     {
       "commands": [
-        "unzip -o *_${gtnh-ver}_Server_Java_17-19.zip"
+        "unzip -o *_${gtnh-ver}_Server_Java_21-19.zip"
       ],
       "type": "command"
     },
@@ -33,18 +33,18 @@
     },
     {
       "commands": [
-        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_17-19.zip"
+        "rm GT_New_Horizons_${gtnh-ver}_Server_Java_21-19.zip"
       ],
       "type": "command"
     },
     {
       "type": "javadl",
-      "version": "17"
+      "version": "21"
     }
   ],
   "run": {
     "stop": "stop",
-    "command": "java17 -Xms${memory}M -Xmx${memory}M -Dfml.readTimeout=180 -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysActAsServerClassMachine -XX:+AlwaysPreTouch -XX:+DisableExplicitGC -XX:+UseNUMA -XX:NmethodSweepActivity=1 -XX:ReservedCodeCacheSize=400M -XX:NonNMethodCodeHeapSize=12M -XX:ProfiledCodeHeapSize=194M -XX:NonProfiledCodeHeapSize=194M -XX:-DontCompileHugeMethods -XX:MaxNodeLimit=240000 -XX:NodeLimitFudgeFactor=8000 -XX:+UseVectorCmov -XX:+PerfDisableSharedMem -XX:+UseFastUnorderedTimeStamps -XX:+UseCriticalJavaThreadPriority -XX:ThreadPriorityPolicy=1 -XX:AllocatePrefetchStyle=3 -XX:+UseG1GC -XX:MaxGCPauseMillis=130 -XX:G1NewSizePercent=28 -XX:G1HeapRegionSize=16M -XX:G1ReservePercent=20 -XX:G1MixedGCCountTarget=3 -XX:InitiatingHeapOccupancyPercent=10 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=0 -XX:SurvivorRatio=32 -XX:MaxTenuringThreshold=1 -XX:G1SATBBufferEnqueueingThresholdPercent=30 -XX:G1ConcMarkStepDurationMillis=5 -XX:G1ConcRSHotCardLimit=16 -XX:G1ConcRefinementServiceIntervalMillis=150 @java9args.txt nogui",
+    "command": "java21 -Xms${memory}M -Xmx${memory}M -Dfml.readTimeout=180 -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysActAsServerClassMachine -XX:+AlwaysPreTouch -XX:+DisableExplicitGC -XX:+UseNUMA -XX:NmethodSweepActivity=1 -XX:ReservedCodeCacheSize=400M -XX:NonNMethodCodeHeapSize=12M -XX:ProfiledCodeHeapSize=194M -XX:NonProfiledCodeHeapSize=194M -XX:-DontCompileHugeMethods -XX:MaxNodeLimit=240000 -XX:NodeLimitFudgeFactor=8000 -XX:+UseVectorCmov -XX:+PerfDisableSharedMem -XX:+UseFastUnorderedTimeStamps -XX:+UseCriticalJavaThreadPriority -XX:ThreadPriorityPolicy=1 -XX:AllocatePrefetchStyle=3 -XX:+UseG1GC -XX:MaxGCPauseMillis=130 -XX:G1NewSizePercent=28 -XX:G1HeapRegionSize=16M -XX:G1ReservePercent=20 -XX:G1MixedGCCountTarget=3 -XX:InitiatingHeapOccupancyPercent=10 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=0 -XX:SurvivorRatio=32 -XX:MaxTenuringThreshold=1 -XX:G1SATBBufferEnqueueingThresholdPercent=30 -XX:G1ConcMarkStepDurationMillis=5 -XX:G1ConcRSHotCardLimit=16 -XX:G1ConcRefinementServiceIntervalMillis=150 @java9args.txt nogui",
     "workingDirectory": "",
     "pre": [],
     "post": [],

--- a/minecraft-mohist/minecraft-mohist-docker.json
+++ b/minecraft-mohist/minecraft-mohist-docker.json
@@ -87,6 +87,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-mohist/minecraft-mohist.json
+++ b/minecraft-mohist/minecraft-mohist.json
@@ -61,7 +61,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-paper/minecraft-paper-docker.json
+++ b/minecraft-paper/minecraft-paper-docker.json
@@ -82,6 +82,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-paper/minecraft-paper.json
+++ b/minecraft-paper/minecraft-paper.json
@@ -58,7 +58,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-purpur/minecraft-purpur-docker.json
+++ b/minecraft-purpur/minecraft-purpur-docker.json
@@ -82,6 +82,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-purpur/minecraft-purpur.json
+++ b/minecraft-purpur/minecraft-purpur.json
@@ -58,7 +58,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-quilt/minecraft-quilt.json
+++ b/minecraft-quilt/minecraft-quilt.json
@@ -49,7 +49,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-spigot/minecraft-spigot-docker.json
+++ b/minecraft-spigot/minecraft-spigot-docker.json
@@ -81,6 +81,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-spigot/minecraft-spigot.json
+++ b/minecraft-spigot/minecraft-spigot.json
@@ -51,7 +51,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },
@@ -67,7 +67,7 @@
     {
       "type": "command",
       "commands": [
-        "java17 -jar BuildTools.jar --rev ${version}"
+        "java21 -jar BuildTools.jar --rev ${version}"
       ]
     },
     {

--- a/minecraft-vanilla/minecraft-vanilla-docker.json
+++ b/minecraft-vanilla/minecraft-vanilla-docker.json
@@ -71,6 +71,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-vanilla/minecraft-vanilla.json
+++ b/minecraft-vanilla/minecraft-vanilla.json
@@ -51,7 +51,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-velocity/minecraft-velocity-docker.json
+++ b/minecraft-velocity/minecraft-velocity-docker.json
@@ -66,6 +66,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-velocity/minecraft-velocity.json
+++ b/minecraft-velocity/minecraft-velocity.json
@@ -50,7 +50,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },

--- a/minecraft-waterfall/minecraft-waterfall-docker.json
+++ b/minecraft-waterfall/minecraft-waterfall-docker.json
@@ -69,6 +69,6 @@
   },
   "environment": {
     "type": "docker",
-    "image": "eclipse-temurin:17"
+    "image": "eclipse-temurin:21"
   }
 }

--- a/minecraft-waterfall/minecraft-waterfall.json
+++ b/minecraft-waterfall/minecraft-waterfall.json
@@ -48,7 +48,7 @@
       "type": "integer",
       "desc": "Version of Java to use",
       "display": "Java Version",
-      "value": "17",
+      "value": "21",
       "required": true
     }
   },


### PR DESCRIPTION
This PR bumps the default Java version value for all Minecraft Java templates to Java 21, in order to increase compatibility by default. Because of this the user doesn't need to tinker, and it is required by 1.20.5 and newer. Newer Java versions work better with older Minecraft versions (doesn't refuse) than newer Minecraft versions do with older Java versions (always refuses if the minimum isn't being met). But the Eclipse Temurin Docker image by PufferPanel should first be updated in order to support Java 21. (I'd love to make some changes but it seems that the Docker image doesn't have a public source which you can contribute to, or well I saw the runtime images but I'm not completely sure about that and it are only a few small changes I think). **Or does it use the original Temurin image? Since it doesn't specify a username**. Specifying Java 21 already right now on the original system (non-Docker) (even though not default) completely works fine.