### PR TITLE
[zomboid] Added two more exec bit changes

### DIFF
--- a/zomboid/zomboid.json
+++ b/zomboid/zomboid.json
@@ -55,6 +55,8 @@
     {
       "type": "command",
       "commands": [
+        "chmod +x jre64/bin/java",
+        "chmod +x ProjectZomboid64",
         "chmod +x start-server.sh"
       ]
     }


### PR DESCRIPTION
start-server.sh requires jre64/bin/java and ProjectZomboid64 to be executable as well