### PR TITLE
Fixed Starbound template not running the correct executable

### DIFF
--- a/starbound/starbound.json
+++ b/starbound/starbound.json
@@ -56,13 +56,13 @@
     {
       "type": "command",
       "commands": [
-        "chmod +x starbound_server"
+        "chmod +x ./linux/starbound_server"
       ]
     }
   ],
   "run": {
     "stopCode": 2,
-    "command": "./starbound_server"
+    "command": "./linux/starbound_server"
   },
   "environment": {
     "type": "tty"


### PR DESCRIPTION
I already brought this up in [this issue](https://github.com/pufferpanel/templates/issues/292), and probably did a better job explaining the issue and steps to fix it there, but a TL;DR is:
The Starbound server template tries modifying the permissions of the server executable as if it's in the root directory, while it's in a folder called `linux`, so it fails to modify the permissions and fails to start it, as the same issue is present while trying to run the binary, this PR should fix it as this seems to fix the issue on my end.