### PR TITLE
Added PaperMC's Folia to Minecraft: Java Edition template

### DIFF
--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -76,6 +76,10 @@
           "display": "Paper"
         },
         {
+          "value": "paper-folia",
+          "display": "Paper Folia"
+        },
+        {
           "value": "spigot",
           "display": "Spigot"
         }
@@ -109,7 +113,7 @@
       "type": "string",
       "value": "latest",
       "display": "Version",
-      "desc": "Version of Minecraft you wish to install. It is best to put a version in, as latest may not work with all server software.",
+      "desc": "Version of Minecraft you wish to install. It is best to put a version in, as latest may not work with all server software. Ignored if Folia is being used.",
       "required": true,
       "userEdit": true
     },
@@ -264,6 +268,26 @@
       "target": "server.jar"
     },
     {
+      "if": "modlauncher == 'paper-folia'",
+      "type": "download",
+      "files": [
+        "https://nightly.link/Slackadays/FoliaToGo/workflows/folia/main/FoliaToGo.zip"
+      ]
+    },
+    {
+      "if": "modlauncher == 'paper-folia'",
+      "type": "command",
+      "commands": [
+        "unzip FoliaToGo.zip -d ."
+      ]
+    },
+    {
+      "if": "modlauncher == 'paper-folia'",
+      "type": "move",
+      "target": "server.jar",
+      "source": "folia-paperclip-*.jar"
+    },
+    {
       "if": "!file_exists(\"server.properties\")",
       "type": "writefile",
       "text": "server-ip=${ip}\nserver-port=${port}\nmotd=${motd}\n",
@@ -311,11 +335,11 @@
     ],
     "pre": [
       {
-          "if": "modlauncher == 'forge'",
-          "type": "resolveforgeversion",
-          "minecraftVersion": "${version}",
-          "version": "${forgebuild}",
-          "outputVariable": "resolvedForgeVersion"
+        "if": "modlauncher == 'forge'",
+        "type": "resolveforgeversion",
+        "minecraftVersion": "${version}",
+        "version": "${forgebuild}",
+        "outputVariable": "resolvedForgeVersion"
       }
     ],
     "stop": "stop",


### PR DESCRIPTION
Greeting, this will be my first PR.
This would solve #263 but probably not in the best way. I found [FoliaToGo](https://github.com/Slackadays/FoliaToGo)'s repository where they have GitHub actions to build Folia source. 
I don't think there is a way to do specific version so this is the best I can get it.

[PaperMC refuses to provide builds for Folia](https://github.com/Slackadays/FoliaToGo?tab=readme-ov-file#motivation)

This does modify the description of the "version" option to include that it would be ignored if Folia is being used.
This PR also does modify the formatting on lines 314-318
This PR requires 'unzip' to be installed on the system.
Folia does require Java 21 to run.

I did make a template for Pufferpanel V2 to automatically build Folia from source, but seeing as dependencies are a massive headache (it isn't on GitHub, and I barely got it to work), I'd rather PR this template instead.