### PR TITLE
Satisfactory 1.0 release servers config update

### DIFF
--- a/satisfactory/satisfactory-docker.json
+++ b/satisfactory/satisfactory-docker.json
@@ -2,18 +2,11 @@
   "type": "srcds",
   "display": "Satisfactory (Docker)",
   "data": {
-    "multihome": {
-      "type": "string",
-      "desc": "Ip address to bind the server to",
-      "display": "Multihome",
-      "value": "0.0.0.0",
-      "userEdit": true
-    },
     "port": {
       "type": "integer",
       "desc": "Port to bind the server to",
       "display": "ServerQueryPort",
-      "value": "15777",
+      "value": "7777",
       "userEdit": true
     }
   },
@@ -22,14 +15,14 @@
       "type": "command",
       "commands": [
         "steamcmd +force_install_dir /pufferpanel +login anonymous +app_update 1690800 +quit",
-        "chmod +x Engine/Binaries/Linux/UnrealServer-Linux-Shipping",
+        "chmod +x Engine/Binaries/Linux/FactoryServer-Linux-Shipping",
         "mkdir -p ./FactoryGame/Saved/Config/LinuxServer/"
       ]
     }
   ],
   "run": {
     "stopCode": 2,
-    "command": "./Engine/Binaries/Linux/UnrealServer-Linux-Shipping FactoryGame ?listen -multihome=${multihome} -ServerQueryPort=${port}",
+    "command": "./Engine/Binaries/Linux/FactoryServer-Linux-Shipping FactoryGame ?listen -ServerQueryPort=${port}",
     "environmentVars": {
       "LD_LIBRARY_PATH": "./linux64:$LD_LIBRARY_PATH"
     }

--- a/satisfactory/satisfactory.json
+++ b/satisfactory/satisfactory.json
@@ -19,18 +19,11 @@
         }
       ]
     },
-    "multihome": {
-      "type": "string",
-      "desc": "Ip address to bind the server to",
-      "display": "Multihome",
-      "value": "0.0.0.0",
-      "userEdit": true
-    },
     "port": {
       "type": "integer",
       "desc": "Port to bind the server to",
       "display": "ServerQueryPort",
-      "value": "15777",
+      "value": "7777",
       "userEdit": true
     }
   },
@@ -42,14 +35,14 @@
     {
       "type": "command",
       "commands": [
-        "chmod +x Engine/Binaries/Linux/UnrealServer-Linux-Shipping",
+        "chmod +x Engine/Binaries/Linux/FactoryServer-Linux-Shipping",
         "mkdir -p ./FactoryGame/Saved/Config/LinuxServer/"
       ]
     }
   ],
   "run": {
     "stopCode": 2,
-    "command": "./Engine/Binaries/Linux/UnrealServer-Linux-Shipping FactoryGame ?listen -multihome=${multihome} -ServerQueryPort=${port}",
+    "command": "./Engine/Binaries/Linux/FactoryServer-Linux-Shipping FactoryGame ?listen -ServerQueryPort=${port}",
     "environmentVars": {
       "LD_LIBRARY_PATH": "./linux64:$LD_LIBRARY_PATH"
     }


### PR DESCRIPTION
Updated config files to work with new Satisfactory 1.0 release.
Multiple changes have been made.
More info can be found in the official clip released [HERE](https://www.youtube.com/watch?v=v8piXNQwcUw)
Also the Multihome command can be removed, more info about why can be found [HERE](https://questions.satisfactorygame.com/post/66e068e6772a987f4a8a98c9)

Changes contained in this PR:
1. Removed multihome command from "satisfactory-docker.json" & "satisfactory.json"
2. Only port 7777 will be used from now on for all connection types.
3. Removed "multihome" parameter from server start command.
4. "UnrealServer-Linux-Shipping" file has been renamed to "FactoryServer-Linux-Shipping" in the 1.0 release.