### PR TITLE
Satisfactory 1.0 release servers config update

### DIFF
--- a/satisfactory/satisfactory.json
+++ b/satisfactory/satisfactory.json
@@ -2,17 +2,9 @@
   "type": "srcds",
   "display": "Satisfactory",
   "data": {
-    "multihome": {
-      "type": "string",
-      "value": "0.0.0.0",
-      "display": "Multihome",
-      "desc": "Ip address to bind the server to",
-      "required": false,
-      "userEdit": false
-    },
     "port": {
       "type": "integer",
-      "value": 15777,
+      "value": 7777,
       "display": "ServerQueryPort",
       "desc": "Port to bind the server to",
       "required": false,
@@ -35,13 +27,13 @@
     {
       "type": "command",
       "commands": [
-        "chmod +x Engine/Binaries/Linux/UnrealServer-Linux-Shipping",
+        "chmod +x Engine/Binaries/Linux/FactoryServer-Linux-Shipping",
         "mkdir -p ./FactoryGame/Saved/Config/LinuxServer/"
       ]
     }
   ],
   "run": {
-    "command": "./Engine/Binaries/Linux/UnrealServer-Linux-Shipping FactoryGame ?listen -multihome=${multihome} -ServerQueryPort=${port}",
+    "command": "./Engine/Binaries/Linux/FactoryServer-Linux-Shipping FactoryGame ?listen -ServerQueryPort=${port}",
     "stopCode": 15,
     "environmentVars": {
       "LD_LIBRARY_PATH": "./linux64"


### PR DESCRIPTION
Updated config files to work with new Satisfactory 1.0 release.
Multiple changes have been made.
More info can be found in the official clip released [HERE](https://www.youtube.com/watch?v=v8piXNQwcUw)
Also the Multihome command can be removed, more info about why can be found [HERE](https://questions.satisfactorygame.com/post/66e068e6772a987f4a8a98c9)

Changes contained in this PR:
1. Removed multihome command from "satisfactory-docker.json" & "satisfactory.json"
2. Only port 7777 will be used from now on for all connection types.
3. Removed "multihome" parameter from server start command.
4. "UnrealServer-Linux-Shipping" file has been renamed to "FactoryServer-Linux-Shipping" in the 1.0 release.