### PR TITLE
fix: Minecraft fabric

### DIFF
--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -179,14 +179,14 @@
       "if": "modlauncher == 'fabric' && env == 'host'",
       "type": "command",
       "commands": [
-        "java${javaversion} -jar fabric-installer.jar server -mcversion ${version} -downloadMinecraft -noprofile"
+        "java${javaversion} -jar fabric-installer.jar server -mcversion ${version} -downloadMinecraft -noprofile -loader default"
       ]
     },
     {
       "if": "modlauncher == 'fabric' && env != 'host'",
       "type": "command",
       "commands": [
-        "java -jar fabric-installer.jar server -mcversion ${version} -downloadMinecraft -noprofile"
+        "java -jar fabric-installer.jar server -mcversion ${version} -downloadMinecraft -noprofile -loader default"
       ]
     },
     {


### PR DESCRIPTION
Append ` -loader latest` to the installer to fix `Caused by: java.lang.IllegalArgumentException: Could not find loader in the arguments`, despite help text suggesting a default.