### PR TITLE
Add version example for Minecraft java template

### DIFF
--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -15,7 +15,7 @@
       "type": "string",
       "value": "",
       "display": "Forge Version",
-      "desc": "Version of Forge to install (may be located <a href='http://files.minecraftforge.net/#Downloads'>here</a>",
+      "desc": "Version of Forge to install (may be located <a href='http://files.minecraftforge.net/#Downloads'>here</a>). Example: (1.21.8-58.1.0)",
       "required": false,
       "userEdit": true
     },

--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -15,7 +15,7 @@
       "type": "string",
       "value": "",
       "display": "Forge Version",
-      "desc": "Version of Forge to install (may be located <a href='http://files.minecraftforge.net/#Downloads'>here</a>). Example: (1.21.8-58.1.0)",
+      "desc": "<a href='http://files.minecraftforge.net/#Downloads'>Version of Forge</a> to install. Example: `1.21.8-58.1.0`",
       "required": false,
       "userEdit": true
     },


### PR DESCRIPTION
Provide version example so users have context to pass in full `minecraft`+`forge` version number.

Users may misunderstand current description and only pass in forge version `58.1.4` instead of the full `1.21.8-58.1.4` version with spaces removed.

Maybe move forge link to `Forge` text to clean up description?