### PR TITLE
update and fix for tshock on host amd64 and add valheimplus initial commit 

### DIFF
--- a/terraria-tshock/terraria-tshock.json
+++ b/terraria-tshock/terraria-tshock.json
@@ -7,7 +7,7 @@
             "type": "option",
             "value": "amd64",
             "display": "Architecture",
-            "desc": "Architecture your machine",
+            "desc": "Architecture of your machine",
             "required": true,
             "userEdit": false,
             "options": [

--- a/terraria-tshock/terraria-tshock.json
+++ b/terraria-tshock/terraria-tshock.json
@@ -1,198 +1,285 @@
 {
-  "type": "terraria",
-  "display": "Terraria - TShock",
-  "icon": "terraria",
-  "data": {
-    "arch": {
-      "type": "option",
-      "value": "x64",
-      "display": "Architecture",
-      "desc": "Architecture your machine",
-      "required": true,
-      "userEdit": false,
-      "options": [
-        {
-          "value": "arm",
-          "display": "arm"
+    "type": "terraria",
+    "display": "Terraria - TShock",
+    "icon": "terraria",
+    "data": {
+        "arch": {
+            "type": "option",
+            "value": "amd64",
+            "display": "Architecture",
+            "desc": "Architecture your machine",
+            "required": true,
+            "userEdit": false,
+            "options": [
+                {
+                    "value": "arm",
+                    "display": "arm"
+                },
+                {
+                    "value": "arm64",
+                    "display": "arm64"
+                },
+                {
+                    "value": "amd64",
+                    "display": "amd64"
+                }
+            ]
         },
-        {
-          "value": "arm64",
-          "display": "arm64"
+        "dotnetversion": {
+            "type": "string",
+            "value": "6.0.36",
+            "display": ".NET Runtime Version",
+            "desc": ".NET Runtime Version",
+            "required": true,
+            "userEdit": false
         },
-        {
-          "value": "x64",
-          "display": "amd64"
+        "ip": {
+            "type": "string",
+            "value": "0.0.0.0",
+            "display": "IP",
+            "desc": "Sets the IP address for the server to listen on - 0.0.0.0 means every possible IP",
+            "required": true,
+            "userEdit": false
+        },
+        "port": {
+            "type": "integer",
+            "value": 7777,
+            "display": "Port",
+            "desc": "What port to bind the server to",
+            "required": true,
+            "userEdit": false
+        },
+        "secure": {
+            "type": "option",
+            "value": "-secure",
+            "display": "secure",
+            "desc": "Enable cheat protection ?",
+            "required": true,
+            "userEdit": false,
+            "options": [
+                {
+                    "value": "-secure",
+                    "display": "Yes"
+                },
+                {
+                    "value": "",
+                    "display": "No"
+                }
+            ]
+        },
+        "tshockversion": {
+            "type": "string",
+            "value": "5.2.4",
+            "display": "TShock Version (Set this to the latest server version - see here https://github.com/Pryaxis/TShock/releases/latest)",
+            "desc": "TShock Version",
+            "required": true,
+            "userEdit": false
+        },
+        "version": {
+            "type": "string",
+            "value": "1.4.4.9",
+            "display": "Server Version",
+            "desc": "Server Version (Set this to the latest server version)",
+            "required": true,
+            "userEdit": false
+        },
+        "wsize": {
+            "type": "option",
+            "value": "3",
+            "display": "World Size",
+            "desc": "World Size to create",
+            "required": true,
+            "userEdit": false,
+            "options": [
+                {
+                    "value": "1",
+                    "display": "Small"
+                },
+                {
+                    "value": "2",
+                    "display": "Medium"
+                },
+                {
+                    "value": "3",
+                    "display": "Large"
+                }
+            ]
         }
-      ]
     },
-    "dotnetversion": {
-      "type": "string",
-      "value": "6.0.14",
-      "display": ".NET Runtime Version",
-      "desc": ".NET Runtime Version",
-      "required": true,
-      "userEdit": false
-    },
-    "ip": {
-      "type": "string",
-      "value": "0.0.0.0",
-      "display": "IP",
-      "desc": "Sets the IP address for the server to listen on - 0.0.0.0 means every possible IP",
-      "required": true,
-      "userEdit": false
-    },
-    "port": {
-      "type": "integer",
-      "value": 7777,
-      "display": "Port",
-      "desc": "What port to bind the server to",
-      "required": true,
-      "userEdit": false
-    },
-    "secure": {
-      "type": "option",
-      "value": "",
-      "display": "secure",
-      "desc": "Enable cheat protection ?",
-      "required": true,
-      "userEdit": false,
-      "options": [
+    "install": [
         {
-          "value": "-secure",
-          "display": "Yes"
+            "if": "env == 'host' && arch == 'amd64'",
+            "type": "download",
+            "files": [
+                "https://dotnetcli.azureedge.net/dotnet/Runtime/${dotnetversion}/dotnet-runtime-${dotnetversion}-linux-x64.tar.gz"
+            ]
         },
         {
-          "value": "",
-          "display": "No"
+            "if": "env == 'host' && arch == 'arm'",
+            "type": "download",
+            "files": [
+                "https://dotnetcli.azureedge.net/dotnet/Runtime/${dotnetversion}/dotnet-runtime-${dotnetversion}-linux-arm.tar.gz"
+            ]
+        },
+        {
+            "if": "env == 'host' && arch == 'arm64'",
+            "type": "download",
+            "files": [
+                "https://dotnetcli.azureedge.net/dotnet/Runtime/${dotnetversion}/dotnet-runtime-${dotnetversion}-linux-arm64.tar.gz"
+            ]
+        },
+        {
+            "if": "env == 'host'",
+            "type": "command",
+            "commands": [
+                "rm -rf dotnet",
+                "mkdir -p dotnet"
+            ]
+        },
+        {
+            "if": "env == 'host' && arch == 'amd64'",
+            "type": "extract",
+            "destination": "dotnet",
+            "source": "dotnet-runtime-${dotnetversion}-linux-x64.tar.gz"
+        },
+        {
+            "if": "env == 'host' && arch == 'arm'",
+            "type": "extract",
+            "source": "dotnet-runtime-${dotnetversion}-linux-arm.tar.gz",
+            "destination": "dotnet"
+        },
+        {
+            "if": "env == 'host' && arch == 'arm64'",
+            "type": "extract",
+            "destination": "dotnet",
+            "source": "dotnet-runtime-${dotnetversion}-linux-arm64.tar.gz"
+        },
+        {
+            "if": "env == 'host' && arch == 'amd64'",
+            "type": "command",
+            "commands": [
+                "rm -rf dotnet-runtime-${dotnetversion}-linux-x64.tar.gz"
+            ]
+        },
+        {
+            "if": "env == 'host' && arch == 'arm'",
+            "type": "command",
+            "commands": [
+                "rm -rf dotnet-runtime-${dotnetversion}-linux-arm.tar.gz"
+            ]
+        },
+        {
+            "if": "env == 'host' && arch == 'arm64'",
+            "type": "command",
+            "commands": [
+                "rm -rf dotnet-runtime-${dotnetversion}-linux-arm64.tar.gz"
+            ]
+        },
+        {
+            "type": "download",
+            "files": [
+                "https://github.com/Pryaxis/TShock/releases/download/v${tshockversion}/TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip"
+            ]
+        },
+        {
+            "type": "extract",
+            "destination": ".",
+            "source": "TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip"
+        },
+        {
+            "if": "arch == 'amd64'",
+            "type": "extract",
+            "destination": ".",
+            "source": "TShock-Beta-linux-x64-Release.tar"
+        },
+        {
+            "if": "arch == 'arm'",
+            "type": "extract",
+            "source": "TShock-Beta-linux-arm-Release.tar",
+            "destination": "."
+        },
+        {
+            "if": "arch == 'arm64'",
+            "type": "extract",
+            "source": "TShock-Beta-linux-arm64-Release.tar",
+            "destination": "."
+        },
+        {
+            "type": "command",
+            "commands": [
+                "mkdir -p worlds"
+            ]
+        },
+        {
+            "if": "arch == 'amd64'",
+            "type": "command",
+            "commands": [
+                "rm -rf TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip",
+                "rm -rf TShock-Beta-linux-x64-Release.tar"
+            ]
+        },
+        {
+            "if": "arch == 'arm'",
+            "type": "command",
+            "commands": [
+                "rm -rf TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip",
+                "rm -rf TShock-Beta-linux-arm-Release.tar"
+            ]
+        },
+        {
+            "if": "arch == 'arm64'",
+            "type": "command",
+            "commands": [
+                "rm -rf TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip",
+                "rm -rf TShock-Beta-linux-arm64-Release.tar"
+            ]
         }
-      ]
+    ],
+    "uninstall": null,
+    "run": {
+        "command": "./TShock.Server -ip ${ip} -port ${port} -world ${rootDir}/worlds/world.wld -autocreate ${wsize} ${secure} --stats-optout",
+        "stop": "exit",
+        "environmentVars": {
+            "DOTNET_ROOT": "./dotnet"
+        },
+        "stdin": {
+            "type": "stdin"
+        },
+        "autostart": false,
+        "autorecover": false,
+        "autorestart": false
     },
-    "tshockversion": {
-      "type": "string",
-      "value": "5.1.3",
-      "display": "TShock Version (Set this to the latest server version - see here https://github.com/Pryaxis/TShock/releases/latest)",
-      "desc": "TShock Version",
-      "required": true,
-      "userEdit": false
+    "environment": {
+        "type": "host"
     },
-    "version": {
-      "type": "string",
-      "value": "1.4.4.9",
-      "display": "Server Version",
-      "desc": "Server Version (Set this to the latest server version)",
-      "required": true,
-      "userEdit": false
-    },
-    "wsize": {
-      "type": "option",
-      "value": "3",
-      "display": "World Size",
-      "desc": "World Size to create",
-      "required": true,
-      "userEdit": false,
-      "options": [
+    "supportedEnvironments": [
         {
-          "value": "1",
-          "display": "Small"
+            "type": "host"
         },
         {
-          "value": "2",
-          "display": "Medium"
-        },
-        {
-          "value": "3",
-          "display": "Large"
+            "type": "docker",
+            "portBindings": [
+                "0.0.0.0:${port}:${port}/tcp"
+            ],
+            "image": "mcr.microsoft.com/dotnet/runtime:${dotnetversion}"
         }
-      ]
-    }
-  },
-  "install": [
-    {
-      "if": "env == 'host'",
-      "type": "download",
-      "files": [
-        "https://dotnetcli.azureedge.net/dotnet/Runtime/${dotnetversion}/dotnet-runtime-${dotnetversion}-linux-${arch}.tar.gz"
-      ]
+    ],
+    "requirements": {
+        "os": "linux",
+        "arch": "amd64",
+        "binaries": [
+            "unzip"
+        ]
     },
-    {
-      "if": "env == 'host'",
-      "type": "command",
-      "commands": [
-        "rm -rf dotnet",
-        "mkdir -p dotnet"
-      ]
+    "stats": {
+        "type": ""
     },
-    {
-      "if": "env == 'host'",
-      "type": "extract",
-      "source": "dotnet-runtime-${dotnetversion}-linux-${arch}.tar.gz",
-      "destination": "dotnet"
+    "query": {
+        "type": ""
     },
-    {
-      "if": "env == 'host'",
-      "type": "command",
-      "commands": [
-        "rm -rf dotnet-runtime-linux-${arch}.tar.gz"
-      ]
+    "keepAlive": {
+        "frequency": "",
+        "command": ""
     },
-    {
-      "type": "download",
-      "files": [
-        "https://github.com/Pryaxis/TShock/releases/download/v${tshockversion}/TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip"
-      ]
-    },
-    {
-      "type": "extract",
-      "source": "TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip",
-      "destination": "."
-    },
-    {
-      "type": "extract",
-      "source": "TShock-Beta-linux-${arch}-Release.tar",
-      "destination": "."
-    },
-    {
-      "type": "command",
-      "commands": [
-        "mkdir worlds",
-        "rm -rf TShock-${tshockversion}-for-Terraria-${version}-linux-${arch}-Release.zip",
-        "rm -rf TShock-Beta-linux-${arch}-Release.tar"
-      ]
-    }
-  ],
-  "run": {
-    "command": "./TShock.Server -ip ${ip} -port ${port} -world ${rootDir}/worlds/world.wld -autocreate ${wsize} ${secure} --stats-optout",
-    "stop": "exit",
-    "environmentVars": {
-      "DOTNET_ROOT": "./dotnet"
-    },
-    "stdin": {
-      "type": "stdin"
-    },
-    "autostart": false,
-    "autorecover": false,
-    "autorestart": false
-  },
-  "environment": {
-    "type": "host"
-  },
-  "supportedEnvironments": [
-    {
-      "type": "host"
-    },
-    {
-      "type": "docker",
-      "image": "mcr.microsoft.com/dotnet/runtime:${dotnetversion}",
-      "portBindings": [
-        "0.0.0.0:${port}:${port}/tcp"
-      ]
-    }
-  ],
-  "requirements": {
-    "os": "linux",
-    "arch": "amd64",
-    "binaries": [
-      "unzip"
-    ]
-  }
+    "name": "Working Tshock"
 }

--- a/valheimplus/valheimplus.json
+++ b/valheimplus/valheimplus.json
@@ -1,0 +1,169 @@
+{
+    "type": "valheim",
+    "display": "ValheimPlus Dedicated Server",
+    "data": {
+        "bepinex_url": {
+            "type": "string",
+            "value": "https://thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2333/",
+            "display": "BepInEx Pack URL",
+            "desc": "BepInExPack_Valheim download URL (required dependency for ValheimPlus).",
+            "required": true,
+            "userEdit": true
+        },
+        "name": {
+            "type": "string",
+            "value": "Valheim Server",
+            "display": "Name",
+            "desc": "Choose your servername.",
+            "required": true,
+            "userEdit": true
+        },
+        "password": {
+            "type": "string",
+            "value": "valheim",
+            "display": "Password",
+            "desc": "Set the server password.",
+            "required": true,
+            "userEdit": true
+        },
+        "port": {
+            "type": "integer",
+            "value": 2456,
+            "display": "Port",
+            "desc": "What port to bind the server to.",
+            "required": true,
+            "userEdit": false
+        },
+        "valheimplus_config_url": {
+            "type": "string",
+            "value": "https://github.com/Grantapher/ValheimPlus/releases/download/0.9.16.2/valheim_plus.cfg",
+            "display": "ValheimPlus Config URL",
+            "desc": "ValheimPlus configuration file URL.",
+            "required": true,
+            "userEdit": true
+        },
+        "valheimplus_url": {
+            "type": "string",
+            "value": "https://thunderstore.io/package/download/Grantapher/ValheimPlus_Grantapher_Temporary/9.16.2/",
+            "display": "ValheimPlus URL",
+            "desc": "ValheimPlus modpack download URL.",
+            "required": true,
+            "userEdit": true
+        },
+        "world": {
+            "type": "string",
+            "value": "VHWorld",
+            "display": "World",
+            "desc": "What worldmap name to use.",
+            "required": true,
+            "userEdit": true
+        }
+    },
+    "install": [
+        {
+            "if": "env == 'host'",
+            "type": "steamgamedl",
+            "appId": "896660"
+        },
+        {
+            "if": "env == 'docker'",
+            "type": "command",
+            "commands": [
+                "steamcmd +force_install_dir /pufferpanel +login anonymous +app_update 896660 +quit"
+            ]
+        },
+        {
+            "type": "download",
+            "files": [
+                "${bepinex_url}"
+            ]
+        },
+        {
+            "type": "command",
+            "commands": [
+                "unzip ./denikson-BepInExPack_Valheim*.zip -d ./bepinex_temp/",
+                "cp -r ./bepinex_temp/BepInExPack_Valheim/. ./",
+                "rm -r ./bepinex_temp",
+                "rm -f ./denikson-BepInExPack_Valheim*.zip"
+            ]
+        },
+        {
+            "type": "download",
+            "files": [
+                "${valheimplus_url}"
+            ]
+        },
+        {
+            "type": "command",
+            "commands": [
+                "unzip ./Grantapher-ValheimPlus_Grantapher_Temporary*.zip -d ./valheimplus_temp/",
+                "cp -r ./valheimplus_temp/. ./",
+                "rm -r ./valheimplus_temp",
+                "rm -f ./Grantapher-ValheimPlus_Grantapher_Temporary*.zip"
+            ]
+        },
+        {
+            "type": "download",
+            "files": [
+                "${valheimplus_config_url}"
+            ]
+        },
+        {
+            "type": "command",
+            "commands": [
+                "mkdir -p ./BepInEx/config",
+                "mv ./valheim_plus.cfg ./BepInEx/config/valheim_plus.cfg"
+            ]
+        },
+        {
+            "type": "command",
+            "commands": [
+                "chmod +x valheim_server.x86_64",
+            ]
+        }
+    ],
+    "uninstall": null,
+    "run": {
+        "command": "./valheim_server.x86_64 -name ${name} -port ${port} -world ${world} -password ${password} -public 1",
+        "stopCode": 2,
+        "environmentVars": {
+            "DOORSTOP_ENABLED": "1",
+            "DOORSTOP_TARGET_ASSEMBLY": "./BepInEx/core/BepInEx.Preloader.dll",
+            "LD_LIBRARY_PATH": "./doorstop_libs:./linux64:$LD_LIBRARY_PATH",
+            "LD_PRELOAD": "libdoorstop_x64.so:$LD_PRELOAD",
+            "SteamAppId": "892970"
+        },
+        "stdin": {
+            "type": "stdin"
+        },
+        "autostart": false,
+        "autorecover": false,
+        "autorestart": false
+    },
+    "environment": {
+        "type": "host"
+    },
+    "supportedEnvironments": [
+        {
+            "type": "host"
+        }
+    ],
+    "requirements": {
+        "os": "linux",
+        "arch": "amd64",
+        "binaries": [
+            "unzip"
+        ]
+    },
+    "stats": {
+        "type": ""
+    },
+    "query": {
+        "type": ""
+    },
+    "keepAlive": {
+        "frequency": "",
+        "command": ""
+    },
+    "name": "ValheimPlus"
+}


### PR DESCRIPTION
TShock
-fix env detection in linux
-fix linux download syntaxs
-fix linux post install file cleanup with tar that comes from zip
-updated dotnet and tshock version

I ONLY TESTED WITH LINUX AMD64 IN HOST MODE MAY HAVE BROKE OTHER ARCHS UPDATING THEM!

ValheimPlus
-added intitial commit for valheimplus only has support for host env on a linux system currently