### PR TITLE
Add resolvedNeoForgeVersion Variable to Minecraft-Java template

### DIFF
--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -133,6 +133,15 @@
       "required": true,
       "userEdit": true,
       "internal": true
+    },
+    "resolvedNeoForgeVersion": {
+      "type": "string",
+      "value": "",
+      "display": "Resolved NeoForge Version",
+      "desc": "Internal, resolved version of NeoForge",
+      "required": true,
+      "userEdit": true,
+      "internal": true
     }
   },
   "groups": [


### PR DESCRIPTION
Quick patch to add a definition for the `resolvedNeoForgeVersion` variable - without it no server was able to start.