### PR TITLE
Update Wiki links 

### DIFF
--- a/ark/README.md
+++ b/ark/README.md
@@ -12,7 +12,7 @@ This template makes it possible to run [ARK: Survival Evolved](http://playark.co
   echo "* hard nofile 1000000" >> /etc/security/limits.conf
   echo "session required pam_limits.so" >> /etc/pam.d/common-session
   ```
-* For more information about prerequisites for ARK server follow this link. https://ark.gamepedia.com/Dedicated_Server_Setup#Prerequisites_2
+* For more information about prerequisites for ARK server follow this link. https://ark.wiki.gg/Dedicated_Server_Setup#Prerequisites_2
 
 
 Current map values available are:

--- a/minecraft-bungeecord/minecraft-bungeecord.json
+++ b/minecraft-bungeecord/minecraft-bungeecord.json
@@ -23,7 +23,7 @@
       "type": "string",
       "value": "A BungeeCord Server &9hosted on PufferPanel",
       "display": "MOTD message of the day",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "required": true,
       "userEdit": true
     },

--- a/minecraft-ftb/minecraft-ftb.json
+++ b/minecraft-ftb/minecraft-ftb.json
@@ -55,7 +55,7 @@
       "type": "string",
       "value": "A Minecraft Server hosted on PufferPanel",
       "display": "MOTD message of the day",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "required": true,
       "userEdit": false
     },

--- a/minecraft-velocity/minecraft-velocity.json
+++ b/minecraft-velocity/minecraft-velocity.json
@@ -31,7 +31,7 @@
       "type": "string",
       "value": "A Velocity proxy &9hosted on PufferPanel",
       "display": "MOTD message of the day",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "required": true,
       "userEdit": true
     },

--- a/minecraft-waterfall/minecraft-waterfall.json
+++ b/minecraft-waterfall/minecraft-waterfall.json
@@ -31,7 +31,7 @@
       "type": "string",
       "value": "A Waterfall Server &9hosted on PufferPanel",
       "display": "MOTD message of the day",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "required": true,
       "userEdit": false
     },

--- a/minecraft/minecraft.json
+++ b/minecraft/minecraft.json
@@ -85,7 +85,7 @@
       "type": "string",
       "value": "A Minecraft Server\\n\\u00A79 hosted on PufferPanel",
       "display": "MOTD message of the day",
-      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.gamepedia.com/Formatting_codes' target='_blank'>color and formatting codes</a>.",
+      "desc": "This is the message that is displayed in the server list of the client, below the name. The MOTD does support <a href='https://minecraft.wiki/w/Formatting_codes' target='_blank'>color and formatting codes</a>.",
       "required": true,
       "userEdit": true
     },


### PR DESCRIPTION
Change the old gamepedia wiki links to the better wiki page for Minecraft and ARK.