### PR TITLE
Update .NET version from 6.0.14 to 8.0.0

### DIFF
--- a/terraria-tmodloader/terraria-tmodloader.json
+++ b/terraria-tmodloader/terraria-tmodloader.json
@@ -265,7 +265,7 @@
     },
     "dotnetversion": {
       "type": "string",
-      "value": "6.0.14",
+      "value": "8.0.0",
       "display": ".NET Runtime Version",
       "desc": ".NET Runtime Version",
       "required": true,


### PR DESCRIPTION
This pull request updates the .NET runtime version used in the `terraria-tmodloader` configuration. The change ensures compatibility with newer features and security updates.

* Dependency upgrade:
  * Updated the `dotnetversion` value from `"6.0.14"` to `"8.0.0"` in `terraria-tmodloader/terraria-tmodloader.json`.